### PR TITLE
Use the uploaded file name as the name of the resource

### DIFF
--- a/src/Routes/AddResource.jsx
+++ b/src/Routes/AddResource.jsx
@@ -147,7 +147,7 @@ export default function AddResource() {
         const resources = JSON.parse(localStorage.getItem('resources')) || [];
         const newResource = {
             id: Math.floor(Math.random() * 10000 + 200),
-            name: formData.name,
+            name: uploadedFiles.length > 0 ? uploadedFiles[0].name : formData.name,
             'start period': combinedRows.length > 0 ? combinedRows[0][0] : '',
             'end period': combinedRows.length > 0 ? combinedRows[combinedRows.length - 1][0] : '',
             indicator: formData.id,


### PR DESCRIPTION
The indicator name was being used as the resource name.

This PR uses the uploaded file name as the PR name. 


* The `name` property of the `newResource` object is now set to the name of the first uploaded file if any files are uploaded, otherwise, it falls back to the name from `formData`.