### PR TITLE
Add Pagination to Admin indicators table

### DIFF
--- a/src/services/indicatorService.js
+++ b/src/services/indicatorService.js
@@ -6,6 +6,11 @@ export const indicatorService = {
     return response.data;
   },
 
+  async getCount() {
+    const response = await apiClient.get('/api/indicators/count');
+    return response.data;
+  },
+
   async getByDomain(domainId, skip = 0, limit = 10) {
     const response = await apiClient.get(`/api/indicators/domain/${domainId}/?skip=${skip}&limit=${limit}`);
     return response.data;


### PR DESCRIPTION
This pull request enhances the pagination functionality in the `IndicatorsManagement` page by introducing total item counts, improving page navigation, and providing clearer pagination feedback to users. It also adds a new API method to fetch the total count of indicators. These changes make the user experience more robust and accurate when browsing large sets of indicators.

**Pagination and Count Improvements**
* Added `hasNextPage` and `totalItems` state variables to track whether more pages are available and the total number of items, respectively.
* Updated the data loading logic to fetch both the paginated indicators and their total count, and to set pagination state based on these values.
* Modified the delete logic for indicators to reload data and update pagination state, including automatically navigating back if the last item on a page is deleted.
* Reset pagination state variables when switching between indicators and domains.

**UI and Controls Enhancements**
* Improved pagination controls layout and added a summary showing the current range and total count of indicators, as well as the current page number. Also, the "Next" button is now correctly disabled when there are no more pages. [[1]](diffhunk://#diff-7e9a7743ccf0a38bcb4d9b5aacd44df7d3e8fd7032316b8be0918a733e063f5fL148-R170) [[2]](diffhunk://#diff-7e9a7743ccf0a38bcb4d9b5aacd44df7d3e8fd7032316b8be0918a733e063f5fL162-R195)

**API Changes**
* Added a new `getCount` method to `indicatorService` for retrieving the total number of indicators from the backend.