### PR TITLE
get domain and indicators page up to figma designs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@tiptap/starter-kit": "^3.12.1",
         "aos": "^2.3.4",
         "apexcharts": "^4.5.0",
-        "axios": "^1.14.0",
+        "axios": "^1.15.0",
         "clsx": "^2.1.1",
         "exceljs": "^4.4.0",
         "fontawesome": "^5.6.3",
@@ -2822,9 +2822,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@tiptap/starter-kit": "^3.12.1",
     "aos": "^2.3.4",
     "apexcharts": "^4.5.0",
-    "axios": "^1.14.0",
+    "axios": "^1.15.0",
     "clsx": "^2.1.1",
     "exceljs": "^4.4.0",
     "fontawesome": "^5.6.3",

--- a/src/components/DomainCard.jsx
+++ b/src/components/DomainCard.jsx
@@ -5,6 +5,7 @@ import arrowRight from '../assets/images/arrow-right.svg';
 
 export default function DomainCard({
   title,
+  domainId,
   page,
   color = "#C3F25E",
   icon,
@@ -20,7 +21,7 @@ export default function DomainCard({
   const handleClick = () => {
     if (page) {
       navigate(page, {
-        state: { domainName: title }
+        state: { domainId }
       });
     }
   };
@@ -68,7 +69,7 @@ export default function DomainCard({
                   e.stopPropagation();
                   if (page) {
                     navigate(`${page}?subdomain=${encodeURIComponent(name)}`, {
-                      state: { domainName: title, subdomain: name }
+                      state: { domainId, subdomain: name }
                     });
                   }
                 }}

--- a/src/components/DomainDropdown.jsx
+++ b/src/components/DomainDropdown.jsx
@@ -12,6 +12,7 @@ function Dropdowns({
   setSelectedSubdomain,
   redirectOnDomainChange = true,
   allowSubdomainClear = true,
+  allowDomainClear = false,
 }) {
   const { domains } = useDomain();
   const navigate = useNavigate();
@@ -44,7 +45,7 @@ function Dropdowns({
     if (redirectOnDomainChange) {
       const path = `/indicators/${domainName.toLowerCase().replace(/\s+/g, '-')}`;
       navigate(path, {
-        state: { domainName: domainName },
+        state: { domainId: domain?.id },
       });
     }
 
@@ -58,38 +59,57 @@ function Dropdowns({
     setIsSubdomainDropdownOpen(false);
   };
 
+  const clearDomain = (e) => {
+    e.stopPropagation();
+    setSelectedDomain(null);
+    setSelectedSubdomain(null);
+  };
+
   const clearSubdomain = (e) => {
     e.stopPropagation();
     setSelectedSubdomain(null);
   };
 
   return (
-    <div className="flex gap-3">
+    <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
       {/* Domain Dropdown */}
       <div ref={domainRef} className="relative">
         <button
           onClick={() => setIsDomainDropdownOpen(!isDomainDropdownOpen)}
-          className="font-['Onest',sans-serif] text-sm text-black bg-[#f1f0f0] rounded-lg px-4 py-3 border-2 border-transparent hover:bg-gray-200 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 transition-colors flex items-center justify-between gap-2 min-w-[200px]"
+          className="font-['Onest',sans-serif] text-sm text-[#0a0a0a] bg-[#fffefc] border border-[#d4d4d4] rounded-full h-10 px-4 shadow-sm hover:bg-black/[0.02] focus:outline-none focus:ring-2 focus:ring-primary/20 transition-colors flex items-center justify-between gap-2 w-full sm:w-auto sm:min-w-[200px]"
         >
-          <span>{getName(selectedDomain) || t('components.select_domain.choose_domain')}</span>
-          <svg
-            className={`w-4 h-4 text-gray-600 transition-transform ${isDomainDropdownOpen ? 'rotate-180' : ''}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-          </svg>
+          <span className="truncate">{getName(selectedDomain) || t('components.select_domain.choose_domain')}</span>
+          <div className="flex items-center gap-1">
+            {selectedDomain?.name && allowDomainClear && (
+              <button
+                onClick={clearDomain}
+                className="hover:bg-black/[0.06] rounded p-0.5 transition-colors"
+                title="Limpar"
+              >
+                <svg className="w-3 h-3 text-[#0a0a0a]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            )}
+            <svg
+              className={`w-4 h-4 text-[#0a0a0a] transition-transform shrink-0 ${isDomainDropdownOpen ? 'rotate-180' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </div>
         </button>
 
         {/* Domain Dropdown Menu */}
         {isDomainDropdownOpen && (
-          <div className="absolute z-50 mt-2 w-full bg-white rounded-lg shadow-lg border border-gray-200 max-h-60 overflow-y-auto">
+          <div className="absolute z-50 mt-2 w-full bg-[#fffefc] rounded-2xl shadow-lg border border-[#e5e5e5] max-h-60 overflow-y-auto">
             {domains.map((domain, index) => (
               <button
                 key={domain?.name || index}
                 onClick={() => handleSelectDomain(domain)}
-                className="font-['Onest',sans-serif] text-sm text-black w-full text-left px-4 py-2 hover:bg-[#f1f0f0] transition-colors first:rounded-t-lg last:rounded-b-lg"
+                className="font-['Onest',sans-serif] text-sm text-[#0a0a0a] w-full text-left px-4 py-2.5 hover:bg-black/[0.03] transition-colors first:rounded-t-2xl last:rounded-b-2xl"
               >
                 {getName(domain) || "Unnamed Domain"}
               </button>
@@ -103,9 +123,9 @@ function Dropdowns({
         <div ref={subdomainRef} className="relative">
           <button
             onClick={() => setIsSubdomainDropdownOpen(!isSubdomainDropdownOpen)}
-            className="font-['Onest',sans-serif] text-sm text-black bg-[#f1f0f0] rounded-lg px-4 py-3 border-2 border-transparent hover:bg-gray-200 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 transition-colors flex items-center justify-between gap-2 min-w-[200px]"
+            className="font-['Onest',sans-serif] text-sm text-[#0a0a0a] bg-[#fffefc] border border-[#d4d4d4] rounded-full h-10 px-4 shadow-sm hover:bg-black/[0.02] focus:outline-none focus:ring-2 focus:ring-primary/20 transition-colors flex items-center justify-between gap-2 w-full sm:w-auto sm:min-w-[200px]"
           >
-            <span>
+            <span className="truncate">
               {getName(selectedSubdomain) || t('components.select_domain.choose_dimension')}
             </span>
             <div className="flex items-center gap-1">
@@ -121,7 +141,7 @@ function Dropdowns({
                 </button>
               )}
               <svg
-                className={`w-4 h-4 text-gray-600 transition-transform ${isSubdomainDropdownOpen ? 'rotate-180' : ''}`}
+                className={`w-4 h-4 text-[#0a0a0a] transition-transform shrink-0 ${isSubdomainDropdownOpen ? 'rotate-180' : ''}`}
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -133,12 +153,12 @@ function Dropdowns({
 
           {/* Subdomain Dropdown Menu */}
           {isSubdomainDropdownOpen && (
-            <div className="absolute z-50 mt-2 w-full bg-white rounded-lg shadow-lg border border-gray-200 max-h-60 overflow-y-auto">
+            <div className="absolute z-50 mt-2 w-full bg-[#fffefc] rounded-2xl shadow-lg border border-[#e5e5e5] max-h-60 overflow-y-auto">
               {(selectedDomain?.subdomains || []).map((subdom, index) => (
                 <button
                   key={typeof subdom === 'string' ? subdom : (subdom?.name || index)}
                   onClick={() => handleSelectSubdomain(typeof subdom === 'string' ? { name: subdom } : subdom)}
-                  className="font-['Onest',sans-serif] text-sm text-black w-full text-left px-4 py-2 hover:bg-[#f1f0f0] transition-colors first:rounded-t-lg last:rounded-b-lg"
+                  className="font-['Onest',sans-serif] text-sm text-[#0a0a0a] w-full text-left px-4 py-2.5 hover:bg-black/[0.03] transition-colors first:rounded-t-2xl last:rounded-b-2xl"
                 >
                   {getName(subdom)}
                 </button>
@@ -158,6 +178,7 @@ Dropdowns.propTypes = {
   setSelectedSubdomain: PropTypes.func.isRequired,
   redirectOnDomainChange: PropTypes.bool,
   allowSubdomainClear: PropTypes.bool,
+  allowDomainClear: PropTypes.bool,
 };
 
 export default Dropdowns;

--- a/src/components/DomainDropdown.jsx
+++ b/src/components/DomainDropdown.jsx
@@ -74,16 +74,21 @@ function Dropdowns({
     <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
       {/* Domain Dropdown */}
       <div ref={domainRef} className="relative">
-        <button
-          onClick={() => setIsDomainDropdownOpen(!isDomainDropdownOpen)}
-          className="font-['Onest',sans-serif] text-sm text-[#0a0a0a] bg-[#fffefc] border border-[#d4d4d4] rounded-full h-10 px-4 shadow-sm hover:bg-black/[0.02] focus:outline-none focus:ring-2 focus:ring-primary/20 transition-colors flex items-center justify-between gap-2 w-full sm:w-auto sm:min-w-[200px]"
-        >
-          <span className="truncate">{getName(selectedDomain) || t('components.select_domain.choose_domain')}</span>
+        <div className="font-['Onest',sans-serif] text-sm text-[#0a0a0a] bg-[#fffefc] border border-[#d4d4d4] rounded-full h-10 px-4 shadow-sm hover:bg-black/[0.02] focus-within:ring-2 focus-within:ring-primary/20 transition-colors flex items-center justify-between gap-2 w-full sm:w-auto sm:min-w-[200px]">
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={() => setIsDomainDropdownOpen(!isDomainDropdownOpen)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setIsDomainDropdownOpen(!isDomainDropdownOpen); } }}
+            className="truncate cursor-pointer flex-1"
+          >
+            {getName(selectedDomain) || t('components.select_domain.choose_domain')}
+          </span>
           <div className="flex items-center gap-1">
             {selectedDomain?.name && allowDomainClear && (
               <button
                 onClick={clearDomain}
-                className="hover:bg-black/[0.06] rounded p-0.5 transition-colors"
+                className="hover:bg-black/[0.06] rounded p-0.5 transition-colors cursor-pointer"
                 title="Limpar"
               >
                 <svg className="w-3 h-3 text-[#0a0a0a]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -92,7 +97,8 @@ function Dropdowns({
               </button>
             )}
             <svg
-              className={`w-4 h-4 text-[#0a0a0a] transition-transform shrink-0 ${isDomainDropdownOpen ? 'rotate-180' : ''}`}
+              className={`w-4 h-4 text-[#0a0a0a] transition-transform shrink-0 cursor-pointer ${isDomainDropdownOpen ? 'rotate-180' : ''}`}
+              onClick={() => setIsDomainDropdownOpen(!isDomainDropdownOpen)}
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -100,7 +106,7 @@ function Dropdowns({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
             </svg>
           </div>
-        </button>
+        </div>
 
         {/* Domain Dropdown Menu */}
         {isDomainDropdownOpen && (
@@ -121,27 +127,31 @@ function Dropdowns({
       {/* Subdomain Dropdown */}
       {selectedDomain && (
         <div ref={subdomainRef} className="relative">
-          <button
-            onClick={() => setIsSubdomainDropdownOpen(!isSubdomainDropdownOpen)}
-            className="font-['Onest',sans-serif] text-sm text-[#0a0a0a] bg-[#fffefc] border border-[#d4d4d4] rounded-full h-10 px-4 shadow-sm hover:bg-black/[0.02] focus:outline-none focus:ring-2 focus:ring-primary/20 transition-colors flex items-center justify-between gap-2 w-full sm:w-auto sm:min-w-[200px]"
-          >
-            <span className="truncate">
+          <div className="font-['Onest',sans-serif] text-sm text-[#0a0a0a] bg-[#fffefc] border border-[#d4d4d4] rounded-full h-10 px-4 shadow-sm hover:bg-black/[0.02] focus-within:ring-2 focus-within:ring-primary/20 transition-colors flex items-center justify-between gap-2 w-full sm:w-auto sm:min-w-[200px]">
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={() => setIsSubdomainDropdownOpen(!isSubdomainDropdownOpen)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setIsSubdomainDropdownOpen(!isSubdomainDropdownOpen); } }}
+              className="truncate cursor-pointer flex-1"
+            >
               {getName(selectedSubdomain) || t('components.select_domain.choose_dimension')}
             </span>
             <div className="flex items-center gap-1">
               {selectedSubdomain?.name && allowSubdomainClear && (
                 <button
                   onClick={clearSubdomain}
-                  className="hover:bg-gray-300 rounded p-0.5 transition-colors"
+                  className="hover:bg-black/[0.06] rounded p-0.5 transition-colors cursor-pointer"
                   title="Limpar"
                 >
-                  <svg className="w-3 h-3 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-3 h-3 text-[#0a0a0a]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 </button>
               )}
               <svg
-                className={`w-4 h-4 text-[#0a0a0a] transition-transform shrink-0 ${isSubdomainDropdownOpen ? 'rotate-180' : ''}`}
+                className={`w-4 h-4 text-[#0a0a0a] transition-transform shrink-0 cursor-pointer ${isSubdomainDropdownOpen ? 'rotate-180' : ''}`}
+                onClick={() => setIsSubdomainDropdownOpen(!isSubdomainDropdownOpen)}
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -149,7 +159,7 @@ function Dropdowns({
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
               </svg>
             </div>
-          </button>
+          </div>
 
           {/* Subdomain Dropdown Menu */}
           {isSubdomainDropdownOpen && (

--- a/src/components/IndicatorCard.jsx
+++ b/src/components/IndicatorCard.jsx
@@ -101,7 +101,7 @@ export default function IndicatorCard({ IndicatorTitle, IndicatorId, domain, sub
 
     return (
         <div
-            className={`bg-base-100 rounded-2xl shadow-sm border border-base-300 transition-all duration-300 hover:shadow-md hover:-translate-y-1 group w-full max-w-sm cursor-pointer relative ${hidden ? 'opacity-50' : ''}`}
+            className={`bg-base-100 rounded-2xl shadow-sm border border-base-300 transition-all duration-300 hover:shadow-md hover:-translate-y-1 group w-full cursor-pointer relative ${hidden ? 'opacity-50' : ''}`}
             onClick={handleClick}
         >
             <style>{`

--- a/src/pages/DomainSelectionPage.jsx
+++ b/src/pages/DomainSelectionPage.jsx
@@ -49,6 +49,7 @@ export default function DomainSelectionPage() {
                 <DomainCard
                   key={domain?.id || index}
                   title={getName(domain) || "Unnamed Domain"}
+                  domainId={domain?.id}
                   page={`/indicators/${domain?.name?.toLowerCase().replace(/\s+/g, '-') || 'unknown'}`}
                   color={domain?.DomainColor || domain?.color}
                   icon={domain?.DomainIcon}

--- a/src/pages/DomainTemplate.jsx
+++ b/src/pages/DomainTemplate.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useDomain } from "../contexts/DomainContext";
 import PageTemplate from "./PageTemplate";
@@ -17,7 +17,7 @@ import { useAuth } from "../contexts/AuthContext";
 export default function DomainTemplate() {
   const location = useLocation();
   const { domainPath } = useParams();
-  const { domainName } = location.state || {};
+  const { domainId: stateDomainId, domainName } = location.state || {};
   const { domains, getDomainByName } = useDomain();
   const getName = useLocalizedName();
   const { t } = useTranslation();
@@ -56,10 +56,12 @@ export default function DomainTemplate() {
     domains: domains.map(d => ({ id: d?.id, name: d?.name }))
   });
   
-  // Find domain by name or fallback
-  const foundDomain = domains.find(dom => 
-    dom?.name === domainName || dom?.name === inferredDomainName
-  ) || getDomainByName(inferredDomainName);
+  // Find domain by ID first, then fallback to name match (PT and EN)
+  const foundDomain = (stateDomainId && domains.find(dom => dom?.id === stateDomainId))
+    || domains.find(dom =>
+      dom?.name === domainName || dom?.name === inferredDomainName ||
+      dom?.name_en === domainName || dom?.name_en === inferredDomainName
+    ) || getDomainByName(inferredDomainName);
   
   const selectedDomainObj = foundDomain || (isAllIndicatorsMode ? null : {
     id: location.pathname.replace("/", ""),
@@ -102,16 +104,25 @@ export default function DomainTemplate() {
   // View mode and search state
   const [viewMode, setViewMode] = useState('grid');
   const [searchInput, setSearchInput] = useState(searchQuery || '');
+  const [isSortDropdownOpen, setIsSortDropdownOpen] = useState(false);
+  const sortRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (sortRef.current && !sortRef.current.contains(e.target)) setIsSortDropdownOpen(false);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
   // Domain state
   const [selectedSubdomain, setSelectedSubdomain] = useState(initialSubdomain);
   const [,setSelectedDomain] = useState(selectedDomainObj);
   const navigateTo = useNavigate();
 
-  const images = selectedDomainObj?.DomainCarouselImages || [
-    "https://img.daisyui.com/images/stock/photo-1609621838510-5ad474b7d25d.webp",
-    "https://img.daisyui.com/images/stock/photo-1414694762283-acccc27bca85.webp"
-  ];
+  const images = selectedDomainObj?.DomainCarouselImages?.length > 0
+    ? selectedDomainObj.DomainCarouselImages
+    : [];
 
   // Graph icons
   const GraphTypes = [
@@ -284,11 +295,11 @@ export default function DomainTemplate() {
       : t('domains.domain_description', { name: (selectedDomainObj?.name || inferredDomainName || '').toLowerCase() });
 
   return (
-    <PageTemplate>
-      <div className="min-h-screen bg-[#f3f4f6]">
+    <PageTemplate fullBleed>
+      <div className="min-h-screen bg-[#f3f4f6] overflow-x-hidden">
         {/* Hero banner — tall image + domain-colored wave + icon */}
-        {!isSearchMode && !isAllIndicatorsMode && (
-          <div className="relative w-full" style={{ marginTop: 'calc(-1 * (var(--navbar-height) + 6rem))' }}>
+        {!isSearchMode && !isAllIndicatorsMode && images.length > 0 && (
+          <div className="relative w-full">
             {/* Dark photo background — ends at wave midpoint */}
             <div className="w-full h-[200px] sm:h-[400px] bg-gray-800">
               {images[0] && (
@@ -296,29 +307,51 @@ export default function DomainTemplate() {
               )}
             </div>
             {/* Spacer for the bottom half of the wave (below the image) */}
-            <div className="w-full h-[100px] bg-[#f3f4f6]" />
+            <div className="w-full h-12 sm:h-24 bg-[#f3f4f6]" />
             {/* Domain-colored wave stroke at bottom of hero */}
+            {/* Mobile: wave */}
             <svg
-              className="absolute bottom-0 left-0 w-full"
-              viewBox="0 0 1512 230"
+              className="absolute bottom-0 left-[-5%] w-[110%] h-20 sm:hidden"
+              viewBox="0 0 433 71"
               fill="none"
               preserveAspectRatio="none"
-              style={{ height: '230px' }}
             >
               <defs>
-                <filter id="wave-shadow" x="-110" y="0" width="1729" height="230" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+                <filter id="domain-mobile-wave" x="0" y="0" width="432.123" height="70.5088" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
                   <feFlood floodOpacity="0" result="BackgroundImageFix"/>
                   <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-                  <feMorphology radius="1.46" operator="dilate" in="SourceAlpha" result="effect1"/>
-                  <feOffset/>
-                  <feGaussianBlur stdDeviation="1.1"/>
+                  <feMorphology radius="0.652927" operator="dilate" in="SourceAlpha" result="effect1"/>
+                  <feOffset/><feGaussianBlur stdDeviation="0.489695"/>
                   <feComposite in2="hardAlpha" operator="out"/>
                   <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0"/>
                   <feBlend mode="normal" in2="BackgroundImageFix" result="effect1"/>
                   <feBlend mode="normal" in="SourceGraphic" in2="effect1" result="shape"/>
                 </filter>
               </defs>
-              <g filter="url(#wave-shadow)">
+              <g filter="url(#domain-mobile-wave)">
+                <path d="M9.59497 26.3733C82.3981 54.3991 127.74 43.7612 190.611 31.5028C280.743 13.9292 338.564 29.4627 426.1 47.1511" stroke={domainColor} strokeWidth="44.329"/>
+              </g>
+            </svg>
+            {/* Desktop: thick wave band */}
+            <svg
+              className="absolute bottom-0 left-0 w-full h-56 hidden sm:block"
+              viewBox="0 0 1512 230"
+              fill="none"
+              preserveAspectRatio="none"
+            >
+              <defs>
+                <filter id="domain-wave-shadow" x="-110" y="0" width="1729" height="230" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+                  <feFlood floodOpacity="0" result="BackgroundImageFix"/>
+                  <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                  <feMorphology radius="1.46" operator="dilate" in="SourceAlpha" result="effect1"/>
+                  <feOffset/><feGaussianBlur stdDeviation="1.1"/>
+                  <feComposite in2="hardAlpha" operator="out"/>
+                  <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0"/>
+                  <feBlend mode="normal" in2="BackgroundImageFix" result="effect1"/>
+                  <feBlend mode="normal" in="SourceGraphic" in2="effect1" result="shape"/>
+                </filter>
+              </defs>
+              <g filter="url(#domain-wave-shadow)">
                 <path
                   d="M-56.7861 98.2787C105.288 132.099 121.652 141.321 293.331 107.848C468.398 73.7143 641.792 88.1376 762.805 119.016C1016 183.621 1352.56 229.014 1565.73 53.2341"
                   stroke={domainColor}
@@ -330,11 +363,7 @@ export default function DomainTemplate() {
             {/* Domain icon — overlapping the wave/content boundary */}
             {domainIcon && (
               <div
-                className="absolute left-4 sm:left-12 bg-white rounded-full p-3 sm:p-5 flex items-center justify-center z-10 w-[68px] h-[68px] sm:w-[112px] sm:h-[112px]"
-                style={{
-                  bottom: '40px',
-                  boxShadow: `0 0 8px rgba(0,0,0,0.05)`,
-                }}
+                className="absolute left-4 sm:left-12 bottom-4 sm:bottom-10 bg-white rounded-full p-3 sm:p-5 flex items-center justify-center z-10 w-17 h-17 sm:w-28 sm:h-28 shadow-sm"
               >
                 <img src={domainIcon} alt="" className="w-[40px] h-[40px] sm:w-[76px] sm:h-[76px] object-contain" />
               </div>
@@ -342,7 +371,7 @@ export default function DomainTemplate() {
           </div>
         )}
 
-        <div className="max-w-[1512px] mx-auto px-4 sm:px-12 pb-20">
+        <div className="max-w-[1512px] mx-auto px-4 sm:px-12 pb-20" style={(!isSearchMode && !isAllIndicatorsMode && images.length > 0) ? undefined : { paddingTop: 'calc(var(--navbar-height) + 6rem)' }}>
           {/* Back button + breadcrumbs */}
           {!isSearchMode && !isAllIndicatorsMode && (
             <div className="flex flex-col gap-4 mb-6 pt-8">
@@ -421,50 +450,70 @@ export default function DomainTemplate() {
             </h2>
 
             {/* Filter bar */}
-            <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-between gap-4">
               {/* Left: filters */}
-              <div className="flex flex-wrap items-center gap-4 sm:gap-6">
-                {/* Domain/Subdomain dropdowns for specific domain mode */}
-                {!isSearchMode && !isAllIndicatorsMode && (
+              <div className="flex flex-wrap items-center gap-3 sm:gap-6 w-full sm:w-auto">
+                {/* Domain/Subdomain dropdowns */}
+                {!isSearchMode && (
                   <Dropdowns
-                    selectedDomain={selectedDomainObj}
-                    setSelectedDomain={setSelectedDomain}
-                    selectedSubdomain={selectedSubdomain}
-                    setSelectedSubdomain={handleSubdomainChange}
-                    redirectOnDomainChange={true}
+                    selectedDomain={isAllIndicatorsMode ? (domainFilter ? domains.find(d => d.id === domainFilter) : null) : selectedDomainObj}
+                    setSelectedDomain={(domain) => {
+                      if (isAllIndicatorsMode) {
+                        setDomainFilter(domain?.id || null);
+                        setSubdomainFilter(null);
+                        setCurrentPage(0);
+                      } else {
+                        setSelectedDomain(domain);
+                      }
+                    }}
+                    selectedSubdomain={isAllIndicatorsMode ? (subdomainFilter ? { name: subdomainFilter } : null) : selectedSubdomain}
+                    setSelectedSubdomain={(sub) => {
+                      if (isAllIndicatorsMode) {
+                        setSubdomainFilter(sub?.name || null);
+                        setCurrentPage(0);
+                      } else {
+                        handleSubdomainChange(sub);
+                      }
+                    }}
+                    redirectOnDomainChange={!isAllIndicatorsMode}
                     allowSubdomainClear={true}
+                    allowDomainClear={isAllIndicatorsMode}
                   />
                 )}
 
                 {/* Sort */}
-                <div className="flex items-center gap-2 bg-[#fffefc] border border-[#d4d4d4] rounded-full h-10 px-4 shadow-sm">
-                  <svg className="w-4 h-4 text-[#0a0a0a]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12" />
-                  </svg>
-                  <select
-                    className="font-['Onest'] bg-transparent text-sm outline-none cursor-pointer text-[#0a0a0a]"
-                    value={sortBy}
-                    onChange={(e) => handleSort(e.target.value)}
+                <div ref={sortRef} className="relative">
+                  <button
+                    onClick={() => setIsSortDropdownOpen(!isSortDropdownOpen)}
+                    className="font-['Onest',sans-serif] text-sm text-[#0a0a0a] bg-[#fffefc] border border-[#d4d4d4] rounded-full h-10 px-4 shadow-sm hover:bg-black/[0.02] transition-colors flex items-center gap-2 cursor-pointer"
                   >
-                    <option value="name">{t('domains.sort_name')}</option>
-                    <option value="periodicity">{t('domains.sort_periodicity')}</option>
-                    <option value="favourites">{t('domains.sort_favorites')}</option>
-                  </select>
-                </div>
-
-                {/* Dimension (domain) filter */}
-                <div className="flex items-center gap-2 bg-[#fffefc] border border-[#d4d4d4] rounded-full h-10 px-4 shadow-sm">
-                  <svg className="w-4 h-4 text-[#0a0a0a]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                  </svg>
-                  <select
-                    className="font-['Onest'] bg-transparent text-sm outline-none cursor-pointer text-[#0a0a0a]"
-                    value={domainFilter || ''}
-                    onChange={(e) => { setDomainFilter(e.target.value || null); setSubdomainFilter(null); setCurrentPage(0); }}
-                  >
-                    <option value="">{t('domains.filter_all_domains')}</option>
-                    {domains.map(d => <option key={d.id} value={d.id}>{getName(d)}</option>)}
-                  </select>
+                    <svg className="w-4 h-4 text-[#0a0a0a] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12" />
+                    </svg>
+                    <span className="truncate">
+                      {sortBy === 'name' ? t('domains.sort_name') : sortBy === 'periodicity' ? t('domains.sort_periodicity') : t('domains.sort_favorites')}
+                    </span>
+                    <svg className={`w-4 h-4 text-[#0a0a0a] shrink-0 transition-transform ${isSortDropdownOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                  {isSortDropdownOpen && (
+                    <div className="absolute z-50 mt-2 w-full bg-[#fffefc] rounded-2xl shadow-lg border border-[#e5e5e5] overflow-hidden">
+                      {[
+                        { value: 'name', label: t('domains.sort_name') },
+                        { value: 'periodicity', label: t('domains.sort_periodicity') },
+                        { value: 'favourites', label: t('domains.sort_favorites') },
+                      ].map((option) => (
+                        <button
+                          key={option.value}
+                          onClick={() => { handleSort(option.value); setIsSortDropdownOpen(false); }}
+                          className={`font-['Onest',sans-serif] text-sm w-full text-left px-4 py-2.5 hover:bg-black/[0.03] transition-colors first:rounded-t-2xl last:rounded-b-2xl ${sortBy === option.value ? 'text-primary font-medium' : 'text-[#0a0a0a]'}`}
+                        >
+                          {option.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </div>
 
                 {/* Governance */}
@@ -480,7 +529,7 @@ export default function DomainTemplate() {
               </div>
 
               {/* Right: view toggle + search */}
-              <div className="flex items-center gap-6 sm:gap-8">
+              <div className="flex items-center gap-4 sm:gap-8 w-full sm:w-auto justify-between sm:justify-end">
                 {/* Grid / Table toggle */}
                 <div className="flex items-center gap-4">
                   <button
@@ -538,7 +587,7 @@ export default function DomainTemplate() {
                 {indicators.filter(ind => ind?.name && ind?.id).length > 0 ? (
                   viewMode === 'grid' ? (
                     /* Grid view */
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6">
                       {indicators
                         .filter(ind => ind?.name && ind?.id)
                         .map((indicator) => (

--- a/src/pages/IndicatorTemplate.jsx
+++ b/src/pages/IndicatorTemplate.jsx
@@ -10,6 +10,7 @@ import GChart from "../components/Chart";
 import Views from "../components/Views";
 import indicatorService from "../services/indicatorService";
 import { useState, useEffect, useCallback, useRef } from "react";
+import { Link } from "react-router-dom";
 
 import useIndicatorData from "../hooks/useIndicatorData";
 import useLocalizedName from "../hooks/useLocalizedName";
@@ -49,6 +50,8 @@ export default function IndicatorTemplate() {
   const [currentPage, setCurrentPage] = useState(0);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [viewport, setViewport] = useState({ min: null, max: null });
+  const [infoOpen, setInfoOpen] = useState(false);
+  const [sourcesOpen, setSourcesOpen] = useState(false);
 
   const isAdmin = user?.role === 'admin';
 
@@ -387,7 +390,9 @@ export default function IndicatorTemplate() {
     });
   };
 
-  const images = resolvedDomainObj.DomainCarouselImages || [];
+  const images = resolvedDomainObj.DomainCarouselImages?.length > 0
+    ? resolvedDomainObj.DomainCarouselImages
+    : [];
 
   const realCharts = [
     {
@@ -404,23 +409,103 @@ export default function IndicatorTemplate() {
     }
   ];
 
-  return (
-    <PageTemplate>
-      <div className="min-h-screen bg-base-100">
-        <section className="text-center pb-12 px-4">
-          <div className="max-w-5xl mx-auto">
-            <h1 className="text-3xl sm:text-5xl md:text-7xl font-bold text-gray-900 mb-4 sm:mb-6 leading-tight font-['Onest',sans-serif]">
-              {getName(indicatorData)}
-            </h1>
-            <p className="text-sm md:text-base text-black mb-8 max-w-2xl mx-auto leading-relaxed">
-              {getName.field(indicatorData, 'description', 'description_en') || t('indicator.default_description', { name: getName(indicatorData) })}
-            </p>
-          </div>
-        </section>
+  const domainColor = resolvedDomainObj?.DomainColor || resolvedDomainObj?.color || '#C3F25E';
+  const domainIcon = resolvedDomainObj?.DomainIcon;
+  const domainPath = resolvedDomainObj?.name
+    ? `/indicators/${resolvedDomainObj.name.toLowerCase().replace(/\s+/g, '-')}`
+    : '/indicators';
 
-        <div className="container mx-auto max-w-7xl px-4 pb-12">
-          <div className="p-4 border-b border-base-300 mb-8">
-            {resolvedDomainObj && (
+  const indicatorResources = indicatorData?.resources
+    ? resources.filter(r => indicatorData.resources.includes(r.id) && (r.startPeriod || r.endPeriod))
+    : [];
+
+  const cardClass = "bg-[#fffefc] rounded-lg p-4 shadow-[0_0_3px_rgba(0,0,0,0.05)]";
+
+  return (
+    <PageTemplate fullBleed>
+      <div className="min-h-screen bg-[#f3f4f6] overflow-x-hidden">
+        {/* Hero banner */}
+        <div className="relative w-full">
+          <div className="w-full h-[200px] sm:h-[400px] bg-gray-800">
+            {images[0] && <img src={images[0]} alt="" className="w-full h-full object-cover opacity-60" />}
+          </div>
+          <div className="w-full h-12 sm:h-24 bg-[#f3f4f6]" />
+          {/* Mobile: wave */}
+          <svg
+            className="absolute bottom-0 left-0 w-full h-20 sm:hidden"
+            viewBox="0 0 433 71"
+            fill="none"
+            preserveAspectRatio="none"
+          >
+            <defs>
+              <filter id="indicator-mobile-wave" x="0" y="0" width="432.123" height="70.5088" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+                <feFlood floodOpacity="0" result="BackgroundImageFix"/>
+                <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                <feMorphology radius="0.652927" operator="dilate" in="SourceAlpha" result="effect1"/>
+                <feOffset/><feGaussianBlur stdDeviation="0.489695"/>
+                <feComposite in2="hardAlpha" operator="out"/>
+                <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0"/>
+                <feBlend mode="normal" in2="BackgroundImageFix" result="effect1"/>
+                <feBlend mode="normal" in="SourceGraphic" in2="effect1" result="shape"/>
+              </filter>
+            </defs>
+            <g filter="url(#indicator-mobile-wave)">
+              <path d="M9.59497 26.3733C82.3981 54.3991 127.74 43.7612 190.611 31.5028C280.743 13.9292 338.564 29.4627 426.1 47.1511" stroke={domainColor} strokeWidth="44.329"/>
+            </g>
+          </svg>
+          <svg
+            className="absolute bottom-0 left-0 w-full h-56 hidden sm:block"
+            viewBox="0 0 1512 230"
+            fill="none"
+            preserveAspectRatio="none"
+          >
+            <defs>
+              <filter id="indicator-wave-shadow" x="-110" y="0" width="1729" height="230" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+                <feFlood floodOpacity="0" result="BackgroundImageFix"/>
+                <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                <feMorphology radius="1.46" operator="dilate" in="SourceAlpha" result="effect1"/>
+                <feOffset/><feGaussianBlur stdDeviation="1.1"/>
+                <feComposite in2="hardAlpha" operator="out"/>
+                <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0"/>
+                <feBlend mode="normal" in2="BackgroundImageFix" result="effect1"/>
+                <feBlend mode="normal" in="SourceGraphic" in2="effect1" result="shape"/>
+              </filter>
+            </defs>
+            <g filter="url(#indicator-wave-shadow)">
+              <path
+                d="M-56.7861 98.2787C105.288 132.099 121.652 141.321 293.331 107.848C468.398 73.7143 641.792 88.1376 762.805 119.016C1016 183.621 1352.56 229.014 1565.73 53.2341"
+                stroke={domainColor}
+                strokeWidth="99.1626"
+                strokeLinecap="round"
+              />
+            </g>
+          </svg>
+          {domainIcon && (
+            <div className="absolute left-4 sm:left-12 bottom-4 sm:bottom-10 bg-white rounded-full p-3 sm:p-5 flex items-center justify-center z-10 w-17 h-17 sm:w-28 sm:h-28 shadow-sm">
+              <img src={domainIcon} alt="" className="w-10 h-10 sm:w-19 sm:h-19 object-contain" />
+            </div>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="max-w-[1512px] mx-auto px-4 sm:px-12 pb-18">
+          {/* Back button */}
+          <div className="pt-6 mb-6">
+            <Link
+              to={domainPath}
+              state={{ domainName: resolvedDomainObj?.name }}
+              className="inline-flex items-center gap-2 border border-[#d4d4d4] rounded-full px-3 py-1 text-sm font-['Onest'] font-medium text-[#0a0a0a] hover:bg-white/60 shadow-sm"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              {t('common.back')}
+            </Link>
+          </div>
+
+          {/* Indicator navigation dropdowns */}
+          {resolvedDomainObj && (
+            <div className="mb-6">
               <IndicatorDropdowns
                 currentDomain={resolvedDomainObj}
                 currentSubdomain={subdomainObj || { name: resolvedSubdomainName }}
@@ -428,321 +513,278 @@ export default function IndicatorTemplate() {
                 onIndicatorChange={handleIndicatorChange}
                 allowSubdomainClear={false}
               />
-            )}
-          </div>
+            </div>
+          )}
 
-          <div className="flex flex-col xl:flex-row gap-4">
-            <div className="flex-1 min-h-0">
-              <div className="bg-base-200 p-4 sm:p-8 rounded-2xl">
-                <div className="flex items-center justify-between mb-2">
-                  <div className="text-sm text-base-content/70">
-                    {t('indicator.last_updated')} {new Date().toLocaleDateString('pt-PT')}
+          <div className="space-y-6">
+            {/* Chart + Sidebar row */}
+            <div className="flex flex-col xl:flex-row gap-6">
+            {/* Chart card */}
+            <div className={`${cardClass} flex-1 min-w-0`}>
+              <div className="flex items-start justify-between gap-4 mb-5">
+                <h2 className="font-['Onest'] font-semibold text-2xl xl:text-3xl text-[#0a0a0a] tracking-tight leading-tight">
+                  {getName(indicatorData)} {indicatorData.unit ? `(${indicatorData.unit})` : ''}
+                </h2>
+                <div className="flex items-center gap-4 shrink-0">
+                  <Views
+                    size="sm"
+                    activeView={chartType}
+                    onViewChange={setChartType}
+                  />
+                </div>
+              </div>
+              <div className="h-72 sm:h-96 xl:h-[550px] relative">
+                {dataLoading && (
+                  <div className="absolute top-4 right-4 z-10">
+                    <div className="loading loading-spinner loading-sm text-primary"></div>
                   </div>
-                  <div className="flex items-center gap-4">
-                    <Views
-                      size="sm"
-                      activeView={chartType}
-                      onViewChange={setChartType}
+                )}
+                {(allLoadedData || chartData)?.series?.[0]?.data?.length > 0 ? (
+                  <div className="h-full">
+                    <GChart
+                      ref={indicatorChartRef}
+                      chartId={`indicator-${indicatorId}`}
+                      chartType={chartType}
+                      xaxisType="datetime"
+                      series={((allLoadedData || chartData)?.series || []).map(s => ({
+                        ...s,
+                        name: getName(indicatorData) || s.name
+                      }))}
+                      height="100%"
+                      showToolbar={true}
+                      showLegend={true}
+                      themeMode="light"
+                      disableAnimations={!isInitialLoad}
+                      onViewportChange={handleViewportChange}
                     />
                   </div>
-                </div>
-
-                <div className="h-[350px] sm:h-[600px] relative">
-                  {dataLoading && (
-                    <div className="absolute top-4 right-4 z-10">
-                      <div className="loading loading-spinner loading-sm text-primary"></div>
-                    </div>
-                  )}
-
-                  {(allLoadedData || chartData)?.series?.[0]?.data?.length > 0 ? (
-                    <div className="h-full">
-                      <GChart
-                        ref={indicatorChartRef}
-                        chartId={`indicator-${indicatorId}`}
-                        chartType={chartType}
-                        xaxisType="datetime"
-                        series={((allLoadedData || chartData)?.series || []).map(s => ({
-                          ...s,
-                          name: getName(indicatorData) || s.name
-                        }))}
-                        height="100%"
-                        showToolbar={true}
-                        showLegend={true}
-                        themeMode="light"
-                        disableAnimations={!isInitialLoad}
-                        onViewportChange={handleViewportChange}
-                      />
-                    </div>
-                  ) : (
-                    !dataLoading ? (
-                      <div className="absolute inset-0 flex justify-center items-center bg-gray-50 rounded-xl">
-                        <div className="text-center">
-                          <div className="w-16 h-16 mx-auto mb-4 text-gray-300">
-                            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 00-2-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                            </svg>
-                          </div>
-                          <div className="text-xl font-medium text-gray-900 mb-2">{t('indicator.no_data_title')}</div>
-                          <div className="text-gray-500">{t('indicator.no_data_description')}</div>
-                        </div>
+                ) : !dataLoading ? (
+                  <div className="absolute inset-0 flex justify-center items-center rounded-lg">
+                    <div className="text-center">
+                      <div className="w-16 h-16 mx-auto mb-4 text-gray-300">
+                        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 00-2-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                        </svg>
                       </div>
-                    ) : (
-                      <div className="absolute inset-0 flex justify-center items-center bg-gray-50/50 rounded-xl">
-                        <div className="flex flex-col items-center gap-3">
-                          <div className="loading loading-spinner loading-lg text-primary"></div>
-                          <div className="text-sm text-gray-500">{t('indicator.loading_data')}</div>
-                        </div>
-                      </div>
-                    )
-                  )}
-                </div>
+                      <div className="text-xl font-medium text-[#0a0a0a] mb-2">{t('indicator.no_data_title')}</div>
+                      <div className="text-[#737373]">{t('indicator.no_data_description')}</div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="absolute inset-0 flex justify-center items-center rounded-lg">
+                    <div className="flex flex-col items-center gap-3">
+                      <div className="loading loading-spinner loading-lg text-primary"></div>
+                      <div className="text-sm text-[#737373]">{t('indicator.loading_data')}</div>
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
 
-            <div className="w-full xl:w-72 space-y-3">
-              <div className="bg-base-200 p-6 rounded-lg">
-                <h3 className="text-lg font-semibold mb-4 text-base-content">{t('indicator.tools')}</h3>
+            {/* Sidebar: Ferramentas + Opções */}
+            <div className="w-full xl:w-84 shrink-0 space-y-6">
+            {/* Ferramentas (Tools) card */}
+            <div className={cardClass}>
+              <div className="flex flex-col gap-4">
+                <h3 className="font-['Onest'] font-semibold text-2xl text-[#0a0a0a] tracking-tight">
+                  {t('indicator.tools')}
+                </h3>
 
                 <div className="space-y-4">
+                  {/* Date range */}
                   <div>
-                    <label className="text-xs font-medium text-base-content/80 mb-2 block">{t('indicator.granularity')}</label>
-                    <div className="flex flex-wrap gap-1">
+                    <p className="font-['Onest'] font-medium text-sm text-[#0a0a0a] mb-2">{t('indicator.granularity')}:</p>
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-center gap-4">
+                        <span className="font-['Onest'] text-sm text-[#0a0a0a] w-6">{t('indicator.start_date_short', 'De')}</span>
+                        <input
+                          type="date"
+                          value={uiStartDate}
+                          onChange={(e) => setUiStartDate(e.target.value)}
+                          className="font-['Onest'] flex-1 px-2 py-1.5 text-sm bg-[#fffefc] border border-[#e5e5e5] rounded-lg shadow-xs focus:outline-none focus:ring-1 focus:ring-primary/30"
+                        />
+                      </div>
+                      <div className="flex items-center gap-4">
+                        <span className="font-['Onest'] text-sm text-[#0a0a0a] w-6">{t('indicator.end_date_short', 'Até')}</span>
+                        <input
+                          type="date"
+                          value={uiEndDate}
+                          onChange={(e) => setUiEndDate(e.target.value)}
+                          className="font-['Onest'] flex-1 px-2 py-1.5 text-sm bg-[#fffefc] border border-[#e5e5e5] rounded-lg shadow-xs focus:outline-none focus:ring-1 focus:ring-primary/30"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Interval selector */}
+                  <div>
+                    <p className="font-['Onest'] font-medium text-sm text-[#0a0a0a] mb-2">{t('indicator.interval', 'Intervalo')}:</p>
+                    <div className="flex">
                       {[
-                        { label: t('indicator.granularity_raw'), value: '0' },
                         { label: t('indicator.granularity_day'), value: '1d' },
-                        { label: t('indicator.granularity_week'), value: '1w' },
                         { label: t('indicator.granularity_month'), value: '1M' },
                         { label: t('indicator.granularity_year'), value: '1y' },
-                      ].map((option) => (
+                      ].map((option, i, arr) => (
                         <button
                           key={option.value}
                           onClick={() => setUiGranularity(option.value)}
-                          className={`px-2 py-1 text-xs rounded border transition-colors ${
-                            uiGranularity === option.value
-                              ? 'bg-primary text-primary-content border-primary'
-                              : 'bg-white border-base-300 text-base-content hover:bg-base-100'
-                          }`}
+                          className={`font-['Onest'] font-medium text-sm px-3 py-2 border border-[#e5e5e5] -ml-px first:ml-0 transition-colors cursor-pointer
+                            ${i === 0 ? 'rounded-l-lg' : ''} ${i === arr.length - 1 ? 'rounded-r-lg' : ''}
+                            ${uiGranularity === option.value ? 'bg-black/[0.03] border-[#d4d4d4] text-[#0a0a0a]' : 'bg-transparent text-[#0a0a0a]'}`}
                         >
                           {option.label}
                         </button>
                       ))}
                     </div>
                   </div>
-
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium text-base-content/80">{t('indicator.start_date')}</span>
-                    <input
-                      type="date"
-                      value={uiStartDate}
-                      onChange={(e) => setUiStartDate(e.target.value)}
-                      className="w-32 px-2 py-1 text-sm bg-white border border-base-300 rounded text-center focus:outline-none focus:ring-1 focus:ring-primary"
-                    />
-                  </div>
-
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium text-base-content/80">{t('indicator.end_date')}</span>
-                    <input
-                      type="date"
-                      value={uiEndDate}
-                      onChange={(e) => setUiEndDate(e.target.value)}
-                      className="w-32 px-2 py-1 text-sm bg-white border border-base-300 rounded text-center focus:outline-none focus:ring-1 focus:ring-primary"
-                    />
-                  </div>
-
-                  <div className="pt-2">
-                    <button
-                      onClick={handleResetFilters}
-                      className="w-full px-3 py-2 bg-white border border-base-300 text-base-content text-sm rounded hover:bg-gray-50 transition-colors cursor-pointer"
-                    >
-                      {t('indicator.reset_filters')}
-                    </button>
-                  </div>
                 </div>
-              </div>
 
-              <div className="bg-base-200 p-6 rounded-lg">
-                <h3 className="text-lg font-semibold mb-4 text-base-content">{t('common.options')}</h3>
-
-                <div className="space-y-3">
-                  <button
-                    onClick={handleExportCSV}
-                    className="w-full flex items-center justify-start gap-3 p-3 bg-white border border-base-300 hover:bg-gray-50 rounded-lg transition-colors cursor-pointer"
-                  >
-                    <svg className="w-5 h-5 text-base-content/60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                    </svg>
-                    <span className="text-sm font-medium text-base-content/80">{t('indicator.export_csv')}</span>
-                  </button>
-
-                  <button
-                    onClick={handleExportImage}
-                    className="w-full flex items-center justify-start gap-3 p-3 bg-white border border-base-300 hover:bg-gray-50 rounded-lg transition-colors cursor-pointer"
-                  >
-                    <svg className="w-5 h-5 text-base-content/60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                    </svg>
-                    <span className="text-sm font-medium text-base-content/80">{t('indicator.export_image')}</span>
-                  </button>
-
-                  <button
-                    onClick={handleCopyReference}
-                    className="w-full flex items-center justify-start gap-3 p-3 bg-white border border-base-300 hover:bg-gray-50 rounded-lg transition-colors cursor-pointer"
-                  >
-                    <svg className="w-5 h-5 text-base-content/60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                    </svg>
-                    <span className="text-sm font-medium text-base-content/80">{t('indicator.copy_reference')}</span>
-                  </button>
-                </div>
+                {/* Reset button */}
+                <button
+                  onClick={handleResetFilters}
+                  className="w-full font-['Onest'] font-medium text-base text-[#0a0a0a] border border-[#d4d4d4] rounded-full py-2 shadow-sm hover:bg-black/[0.02] transition-colors cursor-pointer"
+                >
+                  {t('indicator.reset_filters')}
+                </button>
               </div>
             </div>
-          </div>
-        </div>
 
-        <div className="px-6 pb-6 space-y-6">
-          <div className="bg-base-200 p-6">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-base-content">{t('indicator.info_title')}</h3>
-              {isAdmin && (
-                <button
-                  onClick={handleEditInformation}
-                  className="text-sm text-primary hover:text-primary/80 flex items-center gap-1 cursor-pointer"
-                >
-                  {t('indicator.edit_info')}
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                  </svg>
-                </button>
+            {/* Opções (Options) card */}
+            <div className={cardClass}>
+              <h3 className="font-['Onest'] font-semibold text-2xl text-[#0a0a0a] tracking-tight mb-4">
+                {t('common.options')}
+              </h3>
+              <div className="space-y-2">
+                {[
+                  { action: handleExportCSV, label: t('indicator.export_csv'), icon: "M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" },
+                  { action: handleExportImage, label: t('indicator.export_image'), icon: "M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" },
+                  { action: handleCopyReference, label: t('indicator.copy_reference'), icon: "M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" },
+                  { action: () => { if (navigator.share) navigator.share({ url: window.location.href }); else handleCopyReference(); }, label: t('indicator.share', 'Partilhar'), icon: "M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" },
+                ].map((item, i) => (
+                  <button
+                    key={i}
+                    onClick={item.action}
+                    className="flex items-center gap-4 w-full py-1 cursor-pointer hover:opacity-70 transition-opacity"
+                  >
+                    <div className="w-8 h-8 flex items-center justify-center border border-[#e5e5e5] rounded-lg shadow-sm shrink-0">
+                      <svg className="w-4 h-4 text-[#0a0a0a]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={item.icon} />
+                      </svg>
+                    </div>
+                    <span className="font-['Onest'] text-sm text-[#0a0a0a]">{item.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+            </div>{/* end sidebar */}
+            </div>{/* end chart + sidebar row */}
+
+            {/* Sobre o indicador (About) — accordion */}
+            <div className={cardClass}>
+              <button
+                onClick={() => setInfoOpen(!infoOpen)}
+                className="w-full flex items-center justify-between cursor-pointer"
+              >
+                <h3 className="font-['Onest'] font-semibold text-2xl text-[#0a0a0a] tracking-tight">
+                  {t('indicator.info_title')}
+                </h3>
+                <svg className={`w-7 h-7 text-[#0a0a0a] transition-transform ${infoOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {infoOpen && (
+                <div className="mt-4 space-y-4">
+                  {isAdmin && (
+                    <button
+                      onClick={handleEditInformation}
+                      className="text-sm text-primary hover:text-primary/80 flex items-center gap-1 cursor-pointer"
+                    >
+                      {t('indicator.edit_info')}
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                      </svg>
+                    </button>
+                  )}
+                  {indicatorData.description && (
+                    <p className="font-['Onest'] text-sm text-[#0a0a0a] leading-relaxed">
+                      {getName.field(indicatorData, 'description', 'description_en')}
+                    </p>
+                  )}
+                  <div className="font-['Onest'] text-sm text-[#0a0a0a] space-y-6">
+                    <p><span className="font-semibold">{t('indicator.sources_label')}</span> {indicatorData.characteristics?.source || indicatorData.font || indicatorData.source || "INE"}</p>
+                    <p><span className="font-semibold">{t('indicator.scale_label')}</span> N/A</p>
+                    <p><span className="font-semibold">{t('indicator.units_label')}</span> {indicatorData.characteristics?.unit_of_measure || indicatorData.unit_of_measure || "N/A"}</p>
+                    <p><span className="font-semibold">{t('indicator.periodicity_label')}</span> {indicatorData.characteristics?.periodicity || indicatorData.periodicity || "Anual"}</p>
+                    <p><span className="font-semibold">{t('indicator.governance_label')}</span> {indicatorData?.governance ? t('common.yes') : t('common.no')}</p>
+                    <p><span className="font-semibold">{t('indicator.dimension_label')}</span> {getName(resolvedDomainObj)}</p>
+                    <p><span className="font-semibold">{t('indicator.domain_label')}</span> {resolvedSubdomainName || ""}</p>
+                  </div>
+                </div>
               )}
             </div>
 
-            {indicatorData.description && (
-              <p className="text-base-content/90 mb-4 text-sm leading-relaxed">{indicatorData.description}</p>
-            )}
-
-            <div className="text-sm space-y-1">
-              <div>
-                <span className="font-medium text-base-content/80">{t('indicator.sources_label')} </span>
-                <span className="text-base-content">{indicatorData.characteristics?.source || indicatorData.font || indicatorData.source || "INE"}</span>
-              </div>
-              <div>
-                <span className="font-medium text-base-content/80">{t('indicator.scale_label')} </span>
-                <span className="text-base-content">N/A</span>
-              </div>
-              <div>
-                <span className="font-medium text-base-content/80">{t('indicator.units_label')} </span>
-                <span className="text-base-content">{indicatorData.characteristics?.unit_of_measure || indicatorData.unit_of_measure || "N/A"}</span>
-              </div>
-              <div>
-                <span className="font-medium text-base-content/80">{t('indicator.periodicity_label')} </span>
-                <span className="text-base-content">{indicatorData.characteristics?.periodicity || indicatorData.periodicity || "Anual"}</span>
-              </div>
-              <div>
-                <span className="font-medium text-base-content/80">{t('indicator.governance_label')} </span>
-                <span className="text-base-content">{indicatorData?.governance ? t('common.yes') : t('common.no')}</span>
-              </div>
-              <div>
-                <span className="font-medium text-base-content/80">{t('indicator.dimension_label')} </span>
-                <span className="text-base-content">{getName(resolvedDomainObj)}</span>
-              </div>
-              <div>
-                <span className="font-medium text-base-content/80">{t('indicator.domain_label')} </span>
-                <span className="text-base-content">{resolvedSubdomainName || ""}</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-base-200 p-6">
-            {(() => {
-              const indicatorResources = indicatorData?.resources
-                ? resources.filter(r =>
-                    indicatorData.resources.includes(r.id) &&
-                    (r.startPeriod || r.endPeriod)
-                  )
-                : [];
-              return (
-                <>
-                  <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-lg font-semibold text-base-content">
-                      {t('indicator.sources_title')} ({indicatorResources.length})
-                    </h3>
-                    {isAdmin && (
-                      <button
-                        onClick={handleAddSources}
-                        className="text-sm text-primary hover:text-primary/80 flex items-center gap-1 cursor-pointer"
-                      >
-                        {t('indicator.add_sources')}
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                        </svg>
-                      </button>
-                    )}
-                  </div>
-
-                  {indicatorResources.length === 0 ? (
-                    <div className="text-center py-8 text-base-content/60">
-                      <svg className="w-12 h-12 mx-auto mb-3 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            {/* Fontes do Indicador (Sources) — accordion */}
+            <div className={cardClass}>
+              <button
+                onClick={() => setSourcesOpen(!sourcesOpen)}
+                className="w-full flex items-center justify-between cursor-pointer"
+              >
+                <h3 className="font-['Onest'] font-semibold text-2xl text-[#0a0a0a] tracking-tight">
+                  {t('indicator.sources_title')} ({indicatorResources.length})
+                </h3>
+                <svg className={`w-7 h-7 text-[#0a0a0a] transition-transform ${sourcesOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {sourcesOpen && (
+                <div className="mt-4">
+                  {isAdmin && (
+                    <button
+                      onClick={handleAddSources}
+                      className="text-sm text-primary hover:text-primary/80 flex items-center gap-1 cursor-pointer mb-4"
+                    >
+                      {t('indicator.add_sources')}
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
                       </svg>
+                    </button>
+                  )}
+                  {indicatorResources.length === 0 ? (
+                    <div className="text-center py-8 text-[#737373]">
                       <p>{t('indicator.no_sources')}</p>
                     </div>
                   ) : (
                     <div className="overflow-x-auto">
-                      <table className="w-full">
+                      <table className="w-full font-['Onest']">
                         <thead>
-                          <tr className="border-b border-base-300">
-                            <th className="text-left py-3 px-4 font-medium text-base-content/60">{t('indicator.col_name')}</th>
-                            <th className="text-left py-3 px-4 font-medium text-base-content/60">{t('indicator.col_start_period')}</th>
-                            <th className="text-left py-3 px-4 font-medium text-base-content/60">{t('indicator.col_end_period')}</th>
-                            <th className="text-left py-3 px-4 font-medium text-base-content/60">{t('common.options')}</th>
+                          <tr className="border-b border-[#e5e5e5]">
+                            <th className="text-left py-3 px-4 font-medium text-sm text-[#737373]">{t('indicator.col_name')}</th>
+                            <th className="text-left py-3 px-4 font-medium text-sm text-[#737373]">{t('indicator.col_start_period')}</th>
+                            <th className="text-left py-3 px-4 font-medium text-sm text-[#737373]">{t('indicator.col_end_period')}</th>
+                            <th className="text-left py-3 px-4 font-medium text-sm text-[#737373]">{t('common.options')}</th>
                           </tr>
                         </thead>
                         <tbody>
                           {indicatorResources.map((resource) => (
-                            <tr key={resource.id} className="border-b border-base-300/50">
-                              <td className="py-3 px-4 flex items-center gap-3">
-                                <svg className="w-5 h-5 text-base-content/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                                </svg>
-                                <span className="text-sm text-base-content">{resource.name}</span>
-                              </td>
-                              <td className="py-3 px-4 text-sm text-base-content">
+                            <tr key={resource.id} className="border-b border-[#f3f4f6]">
+                              <td className="py-3 px-4 text-sm text-[#0a0a0a]">{resource.name}</td>
+                              <td className="py-3 px-4 text-sm text-[#0a0a0a]">
                                 {resource.startPeriod ? new Date(resource.startPeriod).toLocaleDateString() : '-'}
                               </td>
-                              <td className="py-3 px-4 text-sm text-base-content">
+                              <td className="py-3 px-4 text-sm text-[#0a0a0a]">
                                 {resource.endPeriod ? new Date(resource.endPeriod).toLocaleDateString() : '-'}
                               </td>
                               <td className="py-3 px-4">
                                 <div className="flex items-center gap-2">
-                                  <button
-                                    onClick={() => handleSourceExportCSV(resource.name)}
-                                    className="text-base-content/40 hover:text-primary transition-colors"
-                                    title={t('indicator.export_csv')}
-                                  >
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                                    </svg>
+                                  <button onClick={() => handleSourceExportCSV(resource.name)} className="text-[#737373] hover:text-primary transition-colors cursor-pointer" title={t('indicator.export_csv')}>
+                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
                                   </button>
-
-                                  <button
-                                    onClick={() => handleSourceView(resource.name)}
-                                    className="text-base-content/40 hover:text-success transition-colors"
-                                    title="Mostrar apenas dados desta fonte no gráfico"
-                                  >
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                                    </svg>
+                                  <button onClick={() => handleSourceView(resource.name)} className="text-[#737373] hover:text-success transition-colors cursor-pointer">
+                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></svg>
                                   </button>
-
                                   {isAdmin && (
-                                    <button
-                                      onClick={() => handleSourceDelete(resource.name)}
-                                      className="text-base-content/40 hover:text-error transition-colors"
-                                      title="Eliminar fonte (apenas administradores)"
-                                    >
-                                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                                      </svg>
+                                    <button onClick={() => handleSourceDelete(resource.name)} className="text-[#737373] hover:text-error transition-colors cursor-pointer">
+                                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
                                     </button>
                                   )}
                                 </div>
@@ -753,12 +795,11 @@ export default function IndicatorTemplate() {
                       </table>
                     </div>
                   )}
-                </>
-              );
-            })()}
+                </div>
+              )}
+            </div>
           </div>
         </div>
-
       </div>
     </PageTemplate>
   );

--- a/src/pages/IndicatorTemplate.jsx
+++ b/src/pages/IndicatorTemplate.jsx
@@ -493,7 +493,7 @@ export default function IndicatorTemplate() {
           <div className="pt-6 mb-6">
             <Link
               to={domainPath}
-              state={{ domainName: resolvedDomainObj?.name }}
+              state={{ domainId: resolvedDomainObj?.id }}
               className="inline-flex items-center gap-2 border border-[#d4d4d4] rounded-full px-3 py-1 text-sm font-['Onest'] font-medium text-[#0a0a0a] hover:bg-white/60 shadow-sm"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -659,7 +659,7 @@ export default function IndicatorTemplate() {
                   { action: handleExportCSV, label: t('indicator.export_csv'), icon: "M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" },
                   { action: handleExportImage, label: t('indicator.export_image'), icon: "M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" },
                   { action: handleCopyReference, label: t('indicator.copy_reference'), icon: "M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" },
-                  { action: () => { if (navigator.share) navigator.share({ url: window.location.href }); else handleCopyReference(); }, label: t('indicator.share', 'Partilhar'), icon: "M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" },
+                  { action: async () => { if (navigator.share) { try { await navigator.share({ url: window.location.href }); } catch { handleCopyReference(); } } else handleCopyReference(); }, label: t('indicator.share', 'Partilhar'), icon: "M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" },
                 ].map((item, i) => (
                   <button
                     key={i}


### PR DESCRIPTION
This pull request introduces several improvements to how domains and subdomains are handled and displayed throughout the application, focusing on more robust state management (using domain IDs instead of names), enhanced UI/UX for dropdowns, and improved visual presentation on the domain template page. The changes increase reliability when navigating between domains, allow for easier clearing of domain selections, and polish the look and feel of domain-related components.

**Domain and Subdomain State Management:**

- Updated navigation and state passing throughout the app to use `domainId` instead of `domainName`, making domain lookups more reliable and less dependent on display names. This affects `DomainCard`, `DomainDropdown`, and routing logic. [[1]](diffhunk://#diff-65c123578f935988dbdf2c57369f18e27b3316b5dc27b7381f7aee53b2c1b4a5R8) [[2]](diffhunk://#diff-65c123578f935988dbdf2c57369f18e27b3316b5dc27b7381f7aee53b2c1b4a5L23-R24) [[3]](diffhunk://#diff-65c123578f935988dbdf2c57369f18e27b3316b5dc27b7381f7aee53b2c1b4a5L71-R72) [[4]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbL47-R48) [[5]](diffhunk://#diff-d71b4ff1bdd4bd1bb54bc67862aa011bbcb16d44c0b4ec3885d07f840fdc518eR52) [[6]](diffhunk://#diff-1ddbfd3f77645236ef309192c6a14602ea9306883a3b50fe7d879cfd17220765L20-R20) [[7]](diffhunk://#diff-1ddbfd3f77645236ef309192c6a14602ea9306883a3b50fe7d879cfd17220765L59-R63)

**DomainDropdown Component Enhancements:**

- Added the ability to clear the selected domain with a new "clear" button, controlled by the `allowDomainClear` prop. Also improved the dropdown’s accessibility and visual style for both domain and subdomain selectors. [[1]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbR15) [[2]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbR62-R112) [[3]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbL106-R128) [[4]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbL124-R144) [[5]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbL136-R161) [[6]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbR181)

**DomainTemplate Page Visual and UX Improvements:**

- Improved hero banner rendering: now only shown if the domain has images; added responsive SVG wave backgrounds for both mobile and desktop; made domain icon placement and styling more consistent. Also, fixed image fallback logic and improved layout responsiveness. [[1]](diffhunk://#diff-1ddbfd3f77645236ef309192c6a14602ea9306883a3b50fe7d879cfd17220765R107-R125) [[2]](diffhunk://#diff-1ddbfd3f77645236ef309192c6a14602ea9306883a3b50fe7d879cfd17220765L287-R354) [[3]](diffhunk://#diff-1ddbfd3f77645236ef309192c6a14602ea9306883a3b50fe7d879cfd17220765L333-R374)

**General UI/UX Polish:**

- Refined button and dropdown styles for better consistency, clarity, and usability across devices, including improved truncation, hover states, and layout adjustments. [[1]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbR62-R112) [[2]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbL106-R128) [[3]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbL124-R144) [[4]](diffhunk://#diff-776fea0a02408abbf979725a94ae7f0159cc21576b1e91fbec1fa70f70431dcbL136-R161)

**Minor Cleanups:**

- Removed unnecessary `max-w-sm` constraint from `IndicatorCard` to improve card layout flexibility.
- Added missing imports and minor refactors for clarity and maintainability.

These changes collectively make the domain selection and navigation experience more robust and visually appealing.