### PR TITLE
fix inverted charts

### DIFF
--- a/src/components/wizard/ResourceWizard.jsx
+++ b/src/components/wizard/ResourceWizard.jsx
@@ -295,16 +295,16 @@ export default function ResourceWizard({
               : w
           ));
 
-          // When wrapper completes, fetch the resource data for visualization
+          // When wrapper completes, fetch resource metadata + data points for preview
           if ((updatedWrapper.status === 'completed' || updatedWrapper.status === 'executing') && updatedWrapper.resource_id) {
             try {
-              const resourceData = await resourceService.getById(updatedWrapper.resource_id);
-              console.log(`Resource data for ${updatedWrapper.resource_id}:`, resourceData);
-
-              // Update wrapper data with resource info
+              const [resourceData, dataResult] = await Promise.all([
+                resourceService.getById(updatedWrapper.resource_id),
+                resourceService.getResourceData(updatedWrapper.resource_id),
+              ]);
               setWrappersData(prev => prev.map(w =>
                 w.wrapper.wrapper_id === updatedWrapper.wrapper_id
-                  ? { ...w, resourceData: resourceData }
+                  ? { ...w, resourceData, chartData: dataResult.data }
                   : w
               ));
             } catch (error) {
@@ -654,30 +654,27 @@ export default function ResourceWizard({
                       {/* Wrapper Data Visualization */}
                       {isComplete && wrapperInfo.resourceData && (
                         <div className="mt-4">
-                          {/* Show data preview */}
                           <div className="bg-[#f1f0f0] rounded-lg p-3 mb-3">
                             <p className="font-['Onest',sans-serif] text-xs text-gray-700">
                               <strong>{t('wizard.resource.resource_created')}</strong> {wrapperInfo.resourceData.name || t('wizard.resource.no_name')}
                             </p>
-                            {wrapperInfo.resourceData.first_entry_date && (
+                            {wrapperInfo.resourceData.startPeriod && (
                               <p className="font-['Onest',sans-serif] text-xs text-gray-600 mt-1">
-                                <strong>{t('wizard.resource.first_entry')}</strong> {new Date(wrapperInfo.resourceData.first_entry_date).toLocaleDateString()}
+                                <strong>{t('wizard.resource.first_entry')}</strong> {new Date(wrapperInfo.resourceData.startPeriod).toLocaleDateString()}
                               </p>
                             )}
-                            {wrapperInfo.resourceData.last_entry_date && (
+                            {wrapperInfo.resourceData.endPeriod && (
                               <p className="font-['Onest',sans-serif] text-xs text-gray-600 mt-1">
-                                <strong>{t('wizard.resource.last_entry')}</strong> {new Date(wrapperInfo.resourceData.last_entry_date).toLocaleDateString()}
+                                <strong>{t('wizard.resource.last_entry')}</strong> {new Date(wrapperInfo.resourceData.endPeriod).toLocaleDateString()}
                               </p>
                             )}
-                            {wrapperInfo.resourceData.total_entries !== undefined && (
+                            {wrapperInfo.wrapper?.data_points_count > 0 && (
                               <p className="font-['Onest',sans-serif] text-xs text-gray-600 mt-1">
-                                <strong>{t('wizard.resource.total_entries')}</strong> {wrapperInfo.resourceData.total_entries}
+                                <strong>{t('wizard.resource.total_entries')}</strong> {wrapperInfo.wrapper.data_points_count}
                               </p>
                             )}
                           </div>
-
-                          {/* Show chart if data series available */}
-                          {wrapperInfo.resourceData.data && wrapperInfo.resourceData.data.length > 0 && (
+                          {wrapperInfo.chartData?.length > 0 && (
                             <GChart
                               title={`Dados - ${wrapperInfo.fileName}`}
                               chartId={`wrapper-chart-${index}`}
@@ -685,12 +682,13 @@ export default function ResourceWizard({
                               xaxisType="datetime"
                               series={[{
                                 name: wrapperInfo.resourceData.name || 'Data',
-                                data: wrapperInfo.resourceData.data.map(entry => ({
-                                  x: new Date(entry.date).getTime(),
-                                  y: parseFloat(entry.value) || 0
+                                data: wrapperInfo.chartData.map(p => ({
+                                  x: new Date(p.x).getTime(),
+                                  y: parseFloat(p.y) || 0
                                 }))
                               }]}
                               height={250}
+                              disableAnimations={true}
                             />
                           )}
                         </div>

--- a/src/hooks/useIndicatorData.js
+++ b/src/hooks/useIndicatorData.js
@@ -21,7 +21,7 @@ export const useIndicatorData = (indicatorId, indicatorName = 'Data', options = 
         setError(null);
         
         // Fetch real data from API with dynamic options
-        const apiData = await dataService.getIndicatorData(indicatorId, 0, limit, 'desc', granularity, startDate, endDate);
+        const apiData = await dataService.getIndicatorData(indicatorId, 0, limit, 'asc', granularity, startDate, endDate);
         
         if (apiData && apiData.length > 0) {
           // Transform real data for chart

--- a/src/pages/IndicatorTemplate.jsx
+++ b/src/pages/IndicatorTemplate.jsx
@@ -211,7 +211,13 @@ export default function IndicatorTemplate() {
       setAllLoadedData(prevData => {
         if (!prevData) {
           setIsLoadingMore(false);
-          return chartData;
+          return {
+            ...chartData,
+            series: chartData.series.map(s => ({
+              ...s,
+              data: [...s.data].sort((a, b) => a.x - b.x)
+            }))
+          };
         } else {
           const mergedData = {
             ...chartData,

--- a/src/pages/ResourcesManagement.jsx
+++ b/src/pages/ResourcesManagement.jsx
@@ -99,11 +99,9 @@ export default function ResourcesManagement() {
         return;
       }
 
-      // Delete the resource
+      // Delete the resource (resource-service publishes resource_deleted event,
+      // which the indicator-service consumes to unlink the resource automatically)
       await resourceService.delete(resourceId);
-
-      // Remove resource from indicator's resource list
-      await indicatorService.removeResource(indicator, resourceId);
 
       // Update local state
       setResources(resources.filter(id => id !== resourceId));

--- a/src/services/resourceService.js
+++ b/src/services/resourceService.js
@@ -69,6 +69,11 @@ export const resourceService = {
     return response.data;
   },
 
+  async getResourceData(resourceId, limit = 500) {
+    const response = await apiClient.get(`/api/resources/${resourceId}/data?limit=${limit}`);
+    return response.data;
+  },
+
   async getFileInfo(fileId) {
     const response = await apiClient.get(`/api/resources/wrappers/files/${fileId}`);
     return response.data;


### PR DESCRIPTION
This pull request introduces several improvements to resource data handling, visualization, and API integration across the resource wizard and related components. Key changes include enhanced data fetching for resource previews, improved chart rendering logic, and cleanup of resource deletion flows. The most important updates are grouped below:

**Resource Data Fetching and Visualization:**

* The `ResourceWizard` now fetches both resource metadata and data points for previewing, storing them separately as `resourceData` and `chartData`, and updates the visualization logic to use these new fields. Chart rendering now uses `chartData` and disables animations for a smoother preview. [[1]](diffhunk://#diff-f65bf06d8470f645cde6b1caa8a6f8a60ec49effa23c7bd916a7366cd7b6100aL298-R307) [[2]](diffhunk://#diff-f65bf06d8470f645cde6b1caa8a6f8a60ec49effa23c7bd916a7366cd7b6100aL657-R691)
* The resource data preview now displays periods using `startPeriod` and `endPeriod` fields, and the total entries count is sourced from `data_points_count` instead of the previous fields.

**API and Service Layer Enhancements:**

* Added a new `getResourceData` method to `resourceService` for fetching resource data points, supporting a configurable limit.

**Chart Data Handling:**

* In the indicator template page, chart series data is now explicitly sorted by the x-axis value to ensure correct visualization order.
* The indicator data hook now fetches indicator data in ascending order rather than descending, so data is presented chronologically.

**Resource Deletion Flow:**

* The resource deletion logic in `ResourcesManagement` has been simplified: after deleting a resource, the indicator-resource unlinking is now handled automatically by the backend event system, so the explicit removal call was removed.