### PR TITLE
Interface/smooth area card

### DIFF
--- a/src/components/AreaCard.jsx
+++ b/src/components/AreaCard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import { AnimatePresence, motion } from 'framer-motion';
 import useLocalizedName from '../hooks/useLocalizedName';
 import arrowRight from '../assets/images/arrow-right.svg';
 
@@ -72,27 +73,38 @@ export default function AreaCard({
         </h3>
 
         {/* Indicators List — vertically centered between title and bottom row */}
-        <ul className="w-full flex flex-col flex-1 justify-center gap-4 sm:gap-9 md:gap-10">
-          {visible.map((ind, i) => {
-            const name = typeof ind === 'string' ? ind : getName(ind) || ind.name;
-            const id = typeof ind === 'object' ? ind.id : null;
-            return (
-              <li
-                key={id || `${currentPage}-${i}`}
-                className="font-['Onest'] font-medium leading-[1.33] text-black underline underline-offset-4 decoration-1 truncate cursor-pointer hover:text-primary transition-colors"
-                style={{ fontSize: 'clamp(0.95rem, 5cqi, 1.25rem)' }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (id) {
-                    navigate(`/indicator/${id}`);
-                  }
-                }}
-              >
-                {name}
-              </li>
-            );
-          })}
-        </ul>
+        <div className="w-full flex flex-col flex-1 justify-center relative">
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.ul
+              key={currentPage}
+              initial={{ opacity: 0, x: 24 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -24 }}
+              transition={{ duration: 0.35, ease: 'easeOut' }}
+              className="w-full flex flex-col gap-4 sm:gap-9 md:gap-10"
+            >
+              {visible.map((ind, i) => {
+                const name = typeof ind === 'string' ? ind : getName(ind) || ind.name;
+                const id = typeof ind === 'object' ? ind.id : null;
+                return (
+                  <li
+                    key={id || `${currentPage}-${i}`}
+                    className="font-['Onest'] font-medium leading-[1.33] text-black underline underline-offset-4 decoration-1 truncate cursor-pointer hover:text-primary transition-colors"
+                    style={{ fontSize: 'clamp(0.95rem, 5cqi, 1.25rem)' }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (id) {
+                        navigate(`/indicator/${id}`);
+                      }
+                    }}
+                  >
+                    {name}
+                  </li>
+                );
+              })}
+            </motion.ul>
+          </AnimatePresence>
+        </div>
 
         {/* Bottom row: page dots + button */}
         <div className="w-full flex items-center justify-between">

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -55,6 +55,7 @@ const GChart = forwardRef(({ title, chartId, chartType, xaxisType, annotations =
     const chartRef = useRef(null)
     const chartContainerRef = useRef(null)
     const onViewportChangeRef = useRef(onViewportChange)
+    const pinnedPointsRef = useRef(new Set())
 
     useImperativeHandle(ref, () => ({
         chart: chartRef.current
@@ -324,8 +325,52 @@ const GChart = forwardRef(({ title, chartId, chartType, xaxisType, annotations =
                         if (onViewportChangeRef.current && xaxis && xaxis.min != null && xaxis.max != null && xaxis.min < xaxis.max) {
                             onViewportChangeRef.current({ min: xaxis.min, max: xaxis.max });
                         }
+                    },
+                    dataPointSelection: function(_event, chartContext, opts) {
+                        const seriesIndex = opts?.seriesIndex;
+                        const dataPointIndex = opts?.dataPointIndex;
+                        if (seriesIndex == null || seriesIndex < 0 || dataPointIndex == null || dataPointIndex < 0) return;
+                        const point = _series?.[seriesIndex]?.data?.[dataPointIndex];
+                        if (!point || point.x == null || point.y == null) return;
+                        const id = `pinned-${seriesIndex}-${dataPointIndex}`;
+                        if (pinnedPointsRef.current.has(id)) {
+                            chartContext.removeAnnotation(id);
+                            pinnedPointsRef.current.delete(id);
+                            return;
+                        }
+                        const xValue = xaxisType === 'datetime'
+                            ? (point.x instanceof Date ? point.x.getTime() : new Date(point.x).getTime())
+                            : point.x;
+                        chartContext.addPointAnnotation({
+                            id,
+                            x: xValue,
+                            y: point.y,
+                            marker: {
+                                size: 5,
+                                fillColor: '#ffffff',
+                                strokeColor: 'var(--color-primary)',
+                                strokeWidth: 2,
+                                radius: 5
+                            },
+                            label: {
+                                borderColor: 'var(--color-primary)',
+                                offsetY: 0,
+                                style: {
+                                    color: 'var(--color-primary-content)',
+                                    background: 'var(--color-primary)',
+                                    fontFamily: 'Onest, sans-serif',
+                                    fontSize: '12px',
+                                    padding: { left: 6, right: 6, top: 2, bottom: 2 }
+                                },
+                                text: formatYValue(point.y)
+                            }
+                        }, false);
+                        pinnedPointsRef.current.add(id);
                     }
                 }
+            },
+            states: {
+                active: { filter: { type: 'none' } }
             },
             plotOptions: {
                 bar: {
@@ -535,6 +580,7 @@ const GChart = forwardRef(({ title, chartId, chartType, xaxisType, annotations =
         if (chartRef.current) {
             try { chartRef.current.destroy() } catch (_) { /* swallow */ }
         }
+        pinnedPointsRef.current = new Set();
 
         try {
             const chart = new ApexCharts(chartContainerRef.current, chartOptions)


### PR DESCRIPTION
This pull request introduces interactive enhancements to the chart component and improves the animation of indicator lists in the area card component. The most significant changes include adding animated transitions to indicator lists and enabling users to pin data points on charts by clicking them. These updates improve the user experience by making list transitions smoother and providing an interactive way to highlight chart data.

**UI Animation Improvements:**
- Added `framer-motion`'s `AnimatePresence` and `motion` to the `AreaCard` component, enabling animated transitions when the list of indicators changes pages. This results in smoother and more visually appealing updates to the indicator list. [[1]](diffhunk://#diff-2ef9d002aeb3d3a1c4bb3df073c6b8e8043ae019e72f47349b2555b9a5f6caa3R5) [[2]](diffhunk://#diff-2ef9d002aeb3d3a1c4bb3df073c6b8e8043ae019e72f47349b2555b9a5f6caa3L75-R85) [[3]](diffhunk://#diff-2ef9d002aeb3d3a1c4bb3df073c6b8e8043ae019e72f47349b2555b9a5f6caa3L95-R107)

**Chart Interactivity Enhancements:**
- Implemented interactive pinning of data points in the `Chart` component: users can now click on a data point to add or remove a labeled annotation (pin) at that point. This is managed via a `pinnedPointsRef` and the new `dataPointSelection` event handler. [[1]](diffhunk://#diff-c95ab27b87eb535de647cc203577cdf8d347e9cbd64b5c1255d1c3667820307eR58) [[2]](diffhunk://#diff-c95ab27b87eb535de647cc203577cdf8d347e9cbd64b5c1255d1c3667820307eR328-R373)
- Ensured that pinned points are reset when the chart is destroyed and re-initialized, preventing stale annotations from persisting across renders.