### PR TITLE
fix xlsx

### DIFF
--- a/src/constants/app.js
+++ b/src/constants/app.js
@@ -3,7 +3,7 @@ export const APP_CONFIG = {
   DEFAULT_ITEMS_PER_PAGE: 10,
   DEFAULT_SORT_ORDER: 'asc',
   DEFAULT_SORT_BY: 'name',
-  MIN_SEARCH_QUERY_LENGTH: 2,
+  MIN_SEARCH_QUERY_LENGTH: 1,
   DATE_FORMAT: 'pt-BR',
   DATE_OPTIONS: {
     year: 'numeric',

--- a/src/hooks/useIndicatorSeries.js
+++ b/src/hooks/useIndicatorSeries.js
@@ -10,7 +10,7 @@ export const useIndicatorSeries = (indicatorId, options = {}) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const { startDate = null, endDate = null, limit = 10000, sort = 'asc' } = options;
+  const { startDate = null, endDate = null, limit = 2000, sort = 'asc', granularity = 'auto', aggregator = 'avg' } = options;
 
   useEffect(() => {
     if (!indicatorId) {
@@ -24,7 +24,7 @@ export const useIndicatorSeries = (indicatorId, options = {}) => {
         setLoading(true);
         setError(null);
         const apiSeries = await dataService.getIndicatorSeries(indicatorId, {
-          limit, sort, startDate, endDate,
+          limit, sort, startDate, endDate, granularity, aggregator,
         });
         if (cancelled) return;
         setSeries(Array.isArray(apiSeries) ? apiSeries : []);
@@ -38,7 +38,7 @@ export const useIndicatorSeries = (indicatorId, options = {}) => {
       }
     })();
     return () => { cancelled = true; };
-  }, [indicatorId, startDate, endDate, limit, sort]);
+  }, [indicatorId, startDate, endDate, limit, sort, granularity, aggregator]);
 
   return { series, loading, error };
 };

--- a/src/pages/AreaTemplate.jsx
+++ b/src/pages/AreaTemplate.jsx
@@ -43,7 +43,12 @@ export default function AreaTemplate({ embedded = false }) {
       .join(" ");
   };
   
-  const inferredAreaName = embedded ? '' : (areaName || (location.pathname === '/all-indicators' ? '' : pathToAreaName(areaPath || location.pathname)));
+  const inferredAreaName = embedded
+    ? ''
+    : (areaName
+      || (location.pathname === '/all-indicators' || location.pathname === '/search'
+        ? ''
+        : pathToAreaName(areaPath || location.pathname)));
   const isAllIndicatorsMode = embedded || (!inferredAreaName && !isSearchMode);
 
   // Debug logging
@@ -290,13 +295,29 @@ export default function AreaTemplate({ embedded = false }) {
   const handleSearchSubmit = useCallback((e) => {
     e.preventDefault();
     const trimmed = searchInput.trim();
-    const basePath = '/indicators';
     if (trimmed) {
-      navigateTo(`${basePath}?q=${encodeURIComponent(trimmed)}`);
+      navigateTo(`/search?q=${encodeURIComponent(trimmed)}`);
     } else if (isSearchMode) {
-      navigateTo(basePath);
+      navigateTo('/search');
     }
   }, [searchInput, isSearchMode, navigateTo, embedded]);
+
+  // Live search: navigate to /search?q=... as the user types so the results
+  // update without needing Enter. Debounced to avoid a request per keystroke.
+  // First nav off a domain page pushes a history entry; subsequent edits
+  // while already on /search replace it so back returns to the source page.
+  useEffect(() => {
+    const trimmed = searchInput.trim();
+    if (trimmed === (searchQuery || '')) return;
+    const handle = setTimeout(() => {
+      if (trimmed) {
+        navigateTo(`/search?q=${encodeURIComponent(trimmed)}`, { replace: isSearchMode });
+      } else if (isSearchMode) {
+        navigateTo('/search', { replace: true });
+      }
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [searchInput, searchQuery, isSearchMode, navigateTo]);
 
   const areaColor = selectedAreaObj?.AreaColor || selectedAreaObj?.color || '#C3F25E';
   const areaIcon = selectedAreaObj?.AreaIcon;

--- a/src/pages/IndicatorTemplate.jsx
+++ b/src/pages/IndicatorTemplate.jsx
@@ -34,7 +34,7 @@ export default function IndicatorTemplate() {
     granularity: 'auto',
     startDate: null,
     endDate: null,
-    limit: 10000
+    limit: 2000
   });
 
   const { series: rawSeries, loading: dataLoading } = useIndicatorSeries(indicatorId, fetchParams);
@@ -275,7 +275,7 @@ export default function IndicatorTemplate() {
       granularity: uiGranularity,
       startDate: uiStartDate ? new Date(uiStartDate).toISOString() : null,
       endDate: uiEndDate ? new Date(uiEndDate).toISOString() : null,
-      limit: 10000,
+      limit: 2000,
     });
   }, [uiGranularity, uiStartDate, uiEndDate, isInitialLoad]);
 
@@ -316,7 +316,7 @@ export default function IndicatorTemplate() {
       granularity: 'auto',
       startDate: null,
       endDate: null,
-      limit: 10000,
+      limit: 2000,
     });
   };
 

--- a/src/services/dataService.js
+++ b/src/services/dataService.js
@@ -22,11 +22,13 @@ export const dataService = {
   // One timeseries per resource attached to the indicator. Each entry feeds a
   // separate line on the chart; names come from the resource (fetched
   // separately) since the indicator-service doesn't keep them.
-  async getIndicatorSeries(indicatorId, { skip = 0, limit = 1000, sort = 'asc', startDate = null, endDate = null } = {}) {
+  async getIndicatorSeries(indicatorId, { skip = 0, limit = 1000, sort = 'asc', startDate = null, endDate = null, granularity = '0', aggregator = 'avg' } = {}) {
     try {
       const params = new URLSearchParams({ skip: String(skip), limit: String(limit), sort });
       if (startDate) params.append('start_date', startDate);
       if (endDate) params.append('end_date', endDate);
+      if (granularity && granularity !== '0') params.append('granularity', granularity);
+      if (aggregator) params.append('aggregator', aggregator);
       const url = `${API_ENDPOINTS.INDICATORS.SERIES(indicatorId)}?${params.toString()}`;
       const response = await apiClient.get(url);
       return response.data || [];


### PR DESCRIPTION
This pull request introduces several improvements and refinements to the indicator data fetching and search experience. The main changes include lowering the minimum search query length, adding support for granularity and aggregation in indicator series queries, reducing the default data fetch limit, and enhancing the search navigation for a more responsive user experience.

**Search Experience Improvements:**

* The minimum search query length has been reduced from 2 to 1 character, allowing users to search with shorter queries. (`src/constants/app.js`)
* Live search navigation is now supported: as the user types in the search box, the app navigates to `/search?q=...` and updates results in real time, with debouncing to avoid excessive requests. (`src/pages/AreaTemplate.jsx`)
* The inferred area name logic now treats `/search` and `/all-indicators` routes consistently, preventing area name inference on these pages. (`src/pages/AreaTemplate.jsx`)

**Indicator Series Data Fetching:**

* The indicator series fetching logic now supports `granularity` and `aggregator` parameters, which are passed through the hook, service, and API call. This allows for more flexible and aggregated data queries. (`src/hooks/useIndicatorSeries.js`, `src/services/dataService.js`) [[1]](diffhunk://#diff-1e56dc0c5e608691b3d797b9a706717714a2948ba5fa22e90e66d20864e2c1a5L13-R13) [[2]](diffhunk://#diff-1e56dc0c5e608691b3d797b9a706717714a2948ba5fa22e90e66d20864e2c1a5L27-R27) [[3]](diffhunk://#diff-1e56dc0c5e608691b3d797b9a706717714a2948ba5fa22e90e66d20864e2c1a5L41-R41) [[4]](diffhunk://#diff-fb1a1b76f98122119d9a19e9bb88e0231954b67e911a958c56e029db04030c57L25-R31)
* The default and maximum fetch limit for indicator series has been reduced from 10,000 to 2,000 to improve performance and avoid excessive data loads. (`src/hooks/useIndicatorSeries.js`, `src/pages/IndicatorTemplate.jsx`) [[1]](diffhunk://#diff-1e56dc0c5e608691b3d797b9a706717714a2948ba5fa22e90e66d20864e2c1a5L13-R13) [[2]](diffhunk://#diff-6f9ac09b6f2e4adeb74366a11d65c8bb41c78187533b62fa43d66a24652ff398L37-R37) [[3]](diffhunk://#diff-6f9ac09b6f2e4adeb74366a11d65c8bb41c78187533b62fa43d66a24652ff398L278-R278) [[4]](diffhunk://#diff-6f9ac09b6f2e4adeb74366a11d65c8bb41c78187533b62fa43d66a24652ff398L319-R319)