### PR TITLE
blog paragraphs, charts fix and weather

### DIFF
--- a/src/components/APIConfigForm.jsx
+++ b/src/components/APIConfigForm.jsx
@@ -6,7 +6,7 @@ const DEFAULT_CONFIG = {
     location: '',
     auth_type: 'none',
     api_key: '',
-    api_key_header: 'X-API-Key',
+    api_key_header: 'api-key',
     bearer_token: '',
     username: '',
     password: '',
@@ -111,7 +111,7 @@ export default function APIConfigForm({ onConfigChange, initialConfig }) {
                         name="api_key_header"
                         value={config.api_key_header}
                         onChange={(value) => handleChange('api_key_header', value)}
-                        placeholder="X-API-Key"
+                        placeholder="api-key"
                     />
                 </>
             )}

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -287,6 +287,7 @@ const GChart = forwardRef(({ title, chartId, chartType, xaxisType, annotations =
         onViewportChangeRef.current = onViewportChange;
     }, [onViewportChange]);
 
+
     useEffect(() => {
         const computedStyle = getComputedStyle(document.documentElement)
         const baseContentColor = computedStyle.getPropertyValue('--color-base-content').trim()
@@ -324,6 +325,38 @@ const GChart = forwardRef(({ title, chartId, chartType, xaxisType, annotations =
     // scatter, bar and column all support x-axis zoom — including bar /
     // column on a category axis (Apex maps the drag to category indices).
     const supportsZoomPan = ['line', 'area', 'scatter', 'bar', 'column', 'stackedColumn', 'stackedBar'].includes(chartType);
+
+    // Apply xaxisRange (viewport zoom/pan) imperatively. Calling
+    // `chart.updateOptions(..., false, false)` lets apex update its internal
+    // min/max without redrawing the whole chart and without animating, which
+    // is critical: during a pan gesture, apex fires `scrolled` on every
+    // tick, the parent stores the new viewport, and a full rebuild here
+    // would tear the chart down mid-drag — making pan look completely
+    // broken even though apex has wired all the events up correctly.
+    useEffect(() => {
+        const chart = chartRef.current;
+        if (!chart || typeof chart.updateOptions !== 'function') return;
+        if (!supportsZoomPan) return;
+        // Only apply an explicit, non-null range. When the parent clears its
+        // viewport (no zoom / no pan history), apex's own min/max recompute
+        // from the data range is what we want — calling updateOptions here
+        // with undefined values forces an unnecessary rebuild and can reset
+        // pan state set up in `mounted`.
+        if (xaxisRange?.min == null || xaxisRange?.max == null) return;
+        const min = xaxisRange.min;
+        const max = xaxisRange.max;
+        // Apex already mutates its own xaxis as the user pans, then fires
+        // `scrolled` which the parent reflects back into `xaxisRange`. If the
+        // values match what apex already has, skip — re-applying them via
+        // updateOptions during an active drag yanks the chart out from under
+        // the gesture and the pan visibly stops moving.
+        const curMin = chart?.w?.config?.xaxis?.min;
+        const curMax = chart?.w?.config?.xaxis?.max;
+        if (curMin === min && curMax === max) return;
+        try {
+            chart.updateOptions({ xaxis: { min, max } }, false, false);
+        } catch (_) { /* swallow */ }
+    }, [xaxisRange?.min, xaxisRange?.max, supportsZoomPan]);
 
     const detectGranularity = (xs) => {
         const dates = (xs || []).map(v => new Date(v)).filter(d => !isNaN(d));
@@ -619,7 +652,7 @@ const GChart = forwardRef(({ title, chartId, chartType, xaxisType, annotations =
                         pan: allowUserInteraction && supportsZoomPan,
                         reset: allowUserInteraction && supportsZoomPan,
                     },
-                    autoSelected: allowUserInteraction && supportsZoomPan ? activeTool : undefined
+                    autoSelected: allowUserInteraction && supportsZoomPan ? activeTool : undefined,
                 },
                 events: {
                     beforeMount: function (chart) {
@@ -830,7 +863,14 @@ const GChart = forwardRef(({ title, chartId, chartType, xaxisType, annotations =
                                 // Strategy 2: coordinate proximity within annotations group
                                 if (!matchId) {
                                     const annotContainer = chartEl.querySelector('.apexcharts-point-annotations');
-                                    const inAnnotations = annotContainer && path.some(n => n === annotContainer || annotContainer.contains(n));
+                                    // `composedPath()` includes Window at the
+                                    // end, which isn't a Node; calling
+                                    // `Node.contains(window)` throws. Restrict
+                                    // the check to actual Node entries.
+                                    const inAnnotations = annotContainer && path.some(n => (
+                                        n === annotContainer
+                                        || (n instanceof Node && annotContainer.contains(n))
+                                    ));
                                     if (inAnnotations) {
                                         for (const [id] of pinnedPointsRef.current) {
                                             const el = annotContainer.querySelector(`.${id}`);
@@ -1247,7 +1287,14 @@ const GChart = forwardRef(({ title, chartId, chartType, xaxisType, annotations =
                 chartRef.current = null
             }
         }
-    }, [title, chartId, chartType, xaxisType, annotations, log, series, group, height, themeMode, labelColor, showLegend, showToolbar, showTooltip, allowUserInteraction, minimalAxis, activeTool, xaxisRange, hiddenSliceLabels, xaxisTitle, yaxisTitle])
+        // `activeTool` and `xaxisRange` are intentionally excluded from the
+        // dep list. Including `xaxisRange` destroys and rebuilds the chart on
+        // every pan tick (because `scrolled` -> `onViewportChange` -> parent
+        // state -> new `xaxisRange` prop), interrupting the drag and making
+        // pan look completely broken. Both are applied imperatively below via
+        // updateOptions / toolbar helpers on the live chart instead.
+    }, [title, chartId, chartType, xaxisType, annotations, log, series, group, height, themeMode, labelColor, showLegend, showToolbar, showTooltip, allowUserInteraction, minimalAxis, activeTool, hiddenSliceLabels, xaxisTitle, yaxisTitle])
+
 
     return <div ref={chartContainerRef} className="w-full h-full" />
 })
@@ -1289,7 +1336,7 @@ GChart.propTypes = {
     allowUserInteraction: PropTypes.bool,
     compact: PropTypes.bool,
     minimalAxis: PropTypes.bool,
-    activeTool: PropTypes.oneOf(['zoom', 'pan', 'selection']),
+    activeTool: PropTypes.oneOf(['zoom', 'pan', 'selection', null]),
     disableAnimations: PropTypes.bool,
     onViewportChange: PropTypes.func,
     xaxisRange: PropTypes.shape({

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1287,12 +1287,11 @@ const GChart = forwardRef(({ title, chartId, chartType, xaxisType, annotations =
                 chartRef.current = null
             }
         }
-        // `activeTool` and `xaxisRange` are intentionally excluded from the
-        // dep list. Including `xaxisRange` destroys and rebuilds the chart on
-        // every pan tick (because `scrolled` -> `onViewportChange` -> parent
-        // state -> new `xaxisRange` prop), interrupting the drag and making
-        // pan look completely broken. Both are applied imperatively below via
-        // updateOptions / toolbar helpers on the live chart instead.
+        // `xaxisRange` is intentionally excluded from the dep list. Including
+        // it destroys and rebuilds the chart on every pan tick (because
+        // `scrolled` -> `onViewportChange` -> parent state -> new `xaxisRange`
+        // prop), interrupting the drag and making pan look broken. Viewport
+        // updates are applied imperatively via `chart.updateOptions` instead.
     }, [title, chartId, chartType, xaxisType, annotations, log, series, group, height, themeMode, labelColor, showLegend, showToolbar, showTooltip, allowUserInteraction, minimalAxis, activeTool, hiddenSliceLabels, xaxisTitle, yaxisTitle])
 
 

--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -43,7 +43,7 @@ export default function PostCard({ post: rawPost, compact = false, catName, base
             </div>
 
             {!compact && post.excerpt && (
-                <p className="font-['Onest'] text-xs text-[#0a0a0a] leading-relaxed line-clamp-3 sm:line-clamp-4">
+                <p className="font-['Onest'] text-xs text-[#0a0a0a] leading-relaxed line-clamp-3 sm:line-clamp-4 whitespace-pre-line">
                     {post.excerpt}
                 </p>
             )}

--- a/src/components/Weather.jsx
+++ b/src/components/Weather.jsx
@@ -90,9 +90,13 @@ export default function Weather({ className = '' }) {
   const current = readings[index] || readings[0];
 
   return (
-    <div className={`flex items-center gap-2 ${className}`}>
+    <div className={`flex items-center gap-2 shrink-0 ${className}`}>
       <WeatherIcon kind={iconFor(current.code, current.isDay)} />
-      <span className="font-['Onest'] font-medium text-[17px] text-[#171717] tracking-[0.085px] whitespace-nowrap">
+      {/* Reserve enough width for the widest label ("Ílhavo 99ºC") so the
+          navbar layout doesn't shift when the city rotates between Ílhavo
+          and Barra — the surrounding nav items used to get squeezed every
+          5 seconds when the text length changed. */}
+      <span className="font-['Onest'] font-medium text-[17px] text-[#171717] tracking-[0.085px] whitespace-nowrap inline-block min-w-[112px]">
         {current.name} {current.temperature}ºC
       </span>
     </div>

--- a/src/components/wizard/CompositionBuilder.jsx
+++ b/src/components/wizard/CompositionBuilder.jsx
@@ -32,7 +32,7 @@ export default function CompositionBuilder({ value, onChange, excludeId, errors 
     (async () => {
       try {
         setLoading(true);
-        const data = await indicatorService.getAll(0, 500, 'name', 'asc');
+        const data = await indicatorService.getAll(0, 500, 'name', 'asc', null, true);
         setAllIndicators(Array.isArray(data) ? data : []);
       } catch (err) {
         console.error('Failed to load indicators for composition:', err);
@@ -65,6 +65,7 @@ export default function CompositionBuilder({ value, onChange, excludeId, errors 
   const bucket = value?.bucket || '1M';
   const aggregator = value?.aggregator || 'avg';
   const name = value?.name || '';
+  const nameEn = value?.name_en || '';
 
   const update = (patch) => onChange({ ...value, ...patch });
 
@@ -87,18 +88,32 @@ export default function CompositionBuilder({ value, onChange, excludeId, errors 
 
   return (
     <div className="space-y-5">
-      {/* Optional display name */}
-      <div>
-        <label className="block text-sm font-medium mb-1">
-          {t('wizard.composition.name_label', 'Nome (opcional)')}
-        </label>
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => update({ name: e.target.value })}
-          placeholder={t('wizard.composition.name_placeholder', 'e.g. Taxa de ocupação')}
-          className="input input-bordered w-full"
-        />
+      {/* Optional display name (PT + EN) */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            {t('wizard.composition.name_label', 'Nome (opcional)')}
+          </label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => update({ name: e.target.value })}
+            placeholder={t('wizard.composition.name_placeholder', 'e.g. Taxa de ocupação')}
+            className="input input-bordered w-full"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            {t('wizard.composition.name_en_label', 'Nome em inglês (opcional)')}
+          </label>
+          <input
+            type="text"
+            value={nameEn}
+            onChange={(e) => update({ name_en: e.target.value })}
+            placeholder={t('wizard.composition.name_en_placeholder', 'e.g. Occupancy rate')}
+            className="input input-bordered w-full"
+          />
+        </div>
       </div>
 
       {/* Inputs list */}
@@ -221,6 +236,7 @@ CompositionBuilder.propTypes = {
     bucket: PropTypes.string,
     aggregator: PropTypes.string,
     name: PropTypes.string,
+    name_en: PropTypes.string,
   }),
   onChange: PropTypes.func.isRequired,
   excludeId: PropTypes.string,

--- a/src/components/wizard/IndicatorPicker.jsx
+++ b/src/components/wizard/IndicatorPicker.jsx
@@ -55,8 +55,8 @@ export default function IndicatorPicker({
         // Load all indicators — the picker is a one-shot selection UI; paging
         // here is more friction than it's worth. Backend caps at 500.
         const data = trimmed.length >= 2
-          ? await indicatorService.search(trimmed, 500, 0, 'relevance')
-          : await indicatorService.getAll(0, 500, 'name', 'asc');
+          ? await indicatorService.search(trimmed, 500, 0, 'relevance', null, null, null, true)
+          : await indicatorService.getAll(0, 500, 'name', 'asc', null, true);
         // Drop responses superseded by a later request, or those that come
         // back after the effect has been cleaned up (cleanup ran).
         if (cancelled || mySeq !== requestSeqRef.current) return;

--- a/src/components/wizard/IndicatorPicker.jsx
+++ b/src/components/wizard/IndicatorPicker.jsx
@@ -55,7 +55,7 @@ export default function IndicatorPicker({
         // Load all indicators — the picker is a one-shot selection UI; paging
         // here is more friction than it's worth. Backend caps at 500.
         const data = trimmed.length >= 2
-          ? await indicatorService.search(trimmed, 500, 0, 'relevance', null, null, null, true)
+          ? await indicatorService.search(trimmed, 500, 0, 'relevance', null, null, null, null, true)
           : await indicatorService.getAll(0, 500, 'name', 'asc', null, true);
         // Drop responses superseded by a later request, or those that come
         // back after the effect has been cleaned up (cleanup ran).

--- a/src/components/wizard/ResourceWizard.jsx
+++ b/src/components/wizard/ResourceWizard.jsx
@@ -62,6 +62,7 @@ export default function ResourceWizard({
     // Composition-mode builder state.
     composition: {
       name: '',
+      name_en: '',
       inputs: [],  // [{ key, indicator_id, indicator }]
       formula: '',
       bucket: '1M',
@@ -71,7 +72,7 @@ export default function ResourceWizard({
       location: '',
       auth_type: 'none',
       api_key: '',
-      api_key_header: 'X-API-Key',
+      api_key_header: 'api-key',
       bearer_token: '',
       username: '',
       password: '',
@@ -617,6 +618,7 @@ export default function ResourceWizard({
         try {
           await indicatorService.addComposition(indicatorId, {
             name: comp.name || null,
+            name_en: comp.name_en || null,
             inputs,
             formula: (comp.formula || '').trim(),
             bucket: comp.bucket || '1M',
@@ -1055,6 +1057,14 @@ export default function ResourceWizard({
                         {t('wizard.composition.name_label', 'Nome')}:
                       </span>{' '}
                       <span className="text-sm">{wizard.formData.composition.name}</span>
+                    </div>
+                  )}
+                  {wizard.formData.composition.name_en && (
+                    <div>
+                      <span className="text-xs text-gray-500">
+                        {t('wizard.composition.name_en_label', 'Nome em inglês')}:
+                      </span>{' '}
+                      <span className="text-sm">{wizard.formData.composition.name_en}</span>
                     </div>
                   )}
                   <div>

--- a/src/pages/BlogPage.jsx
+++ b/src/pages/BlogPage.jsx
@@ -44,7 +44,7 @@ function FeaturedPost({ post: rawPost, catName }) {
                         {post.title}
                     </h2>
                     {post.excerpt && (
-                        <p className="font-['Onest'] font-medium text-lg text-[#0a0a0a] leading-normal line-clamp-3">
+                        <p className="font-['Onest'] font-medium text-lg text-[#0a0a0a] leading-normal line-clamp-3 whitespace-pre-line">
                             {post.excerpt}
                         </p>
                     )}

--- a/src/pages/BlogPostForm.jsx
+++ b/src/pages/BlogPostForm.jsx
@@ -257,7 +257,12 @@ export default function BlogPostForm() {
         status: 'draft',
         categories: [],
         keywords: [],
-        tags: []
+        tags: [],
+        // Local 'YYYY-MM-DD' chosen at create time; converted to ISO before
+        // sending to the backend. On edit we load the existing date here for
+        // display purposes only — the form never sends `published_at` again,
+        // so the chosen date stays fixed for the life of the post.
+        published_at: ''
     })
     const [tagInput, setTagInput] = useState('')
     const [allCategories, setAllCategories] = useState([])
@@ -320,7 +325,7 @@ export default function BlogPostForm() {
                 title: '', title_en: '', content: '', content_en: '', excerpt: '', excerpt_en: '',
                 author: '', author_id: '', author_photo: '', author_role: '', post_type: routePostType,
                 publication_link: '', publication_link_label: '', publication_link_label_en: '',
-                status: 'draft', categories: [], keywords: [], tags: []
+                status: 'draft', categories: [], keywords: [], tags: [], published_at: ''
             }
             setInitialFormData(empty)
         }
@@ -394,7 +399,11 @@ export default function BlogPostForm() {
                 status: postData.status,
                 categories: postData.categories || [],
                 keywords: postData.keywords || [],
-                tags: postData.tags || []
+                tags: postData.tags || [],
+                // For display only on edit; we won't send it back.
+                published_at: postData.published_at
+                    ? new Date(postData.published_at).toISOString().slice(0, 10)
+                    : '',
             }
             setFormData(loadedFormData)
             setInitialFormData(loadedFormData) // Set initial data for change tracking
@@ -681,11 +690,23 @@ export default function BlogPostForm() {
             let savedPost
 
             if (isEditing) {
-                // Update existing post
-                savedPost = await blogService.updatePost(postId, formData)
+                // The publication date is locked once the post is created —
+                // strip it from the update payload so the backend keeps the
+                // originally chosen value untouched.
+                // eslint-disable-next-line no-unused-vars
+                const { published_at: _ignored, ...updatePayload } = formData
+                savedPost = await blogService.updatePost(postId, updatePayload)
             } else {
-                // Create new post
-                savedPost = await blogService.createPost(formData)
+                // Create new post — convert the YYYY-MM-DD picker value to an
+                // ISO datetime (midnight UTC of that day). Empty value falls
+                // back to backend default behavior (auto-set on publish).
+                const createPayload = { ...formData }
+                if (formData.published_at) {
+                    createPayload.published_at = new Date(`${formData.published_at}T00:00:00Z`).toISOString()
+                } else {
+                    delete createPayload.published_at
+                }
+                savedPost = await blogService.createPost(createPayload)
             }
 
             // Upload thumbnail if provided
@@ -1198,6 +1219,33 @@ export default function BlogPostForm() {
                                 />
                             </div>
                         )}
+
+                        {/* Publication date — editable on create, read-only on edit */}
+                        <div>
+                            <label className="block font-['Onest'] text-xs font-medium text-[#737373] mb-2">
+                                {t('admin.blog.field_published_at', 'Data de publicação')}
+                            </label>
+                            {isEditing ? (
+                                <div className="w-full px-3 py-2 font-['Onest'] text-sm bg-[#f3f4f6] border border-[#e5e5e5] rounded-lg text-[#0a0a0a]">
+                                    {formData.published_at
+                                        ? new Date(`${formData.published_at}T00:00:00Z`).toLocaleDateString('pt-PT', { timeZone: 'UTC' })
+                                        : t('admin.blog.field_published_at_unset', 'Sem data (será definida ao publicar)')}
+                                </div>
+                            ) : (
+                                <>
+                                    <input
+                                        type="date"
+                                        name="published_at"
+                                        value={formData.published_at}
+                                        onChange={handleInputChange}
+                                        className="w-full px-3 py-2 font-['Onest'] text-sm bg-[#fffefc] border border-[#e5e5e5] rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#009368]/30"
+                                    />
+                                    <p className="mt-1 font-['Onest'] text-xs text-[#737373]">
+                                        {t('admin.blog.field_published_at_hint', 'Em branco assume a data de publicação. Não poderá ser alterada depois de criar.')}
+                                    </p>
+                                </>
+                            )}
+                        </div>
 
                         {/* Excerpt — mandatory for publications, optional for news-events */}
                         <div>

--- a/src/pages/BlogPostPage.jsx
+++ b/src/pages/BlogPostPage.jsx
@@ -228,22 +228,34 @@ export default function BlogPostPage() {
                 <div className={`bg-[#fffefc] rounded-2xl flex flex-col gap-4 shadow-[0_0_3px_rgba(0,0,0,0.05)] ${mobile ? 'p-4' : 'px-8 py-6'}`}>
                     <h3 className="font-['Onest'] font-semibold text-2xl text-[#0a0a0a] tracking-tight">{t('blog.related_publications')}</h3>
                     <div className="flex flex-col gap-4">
-                        {relatedPosts.map((rp) => (
-                            <Link key={rp.id} to={`${backPath}/${rp.id}`}
-                                className="flex gap-4 items-start no-underline hover:opacity-80 transition-opacity">
-                                <div className="w-[60px] h-[60px] rounded-lg overflow-hidden bg-gray-200 shrink-0 flex items-center justify-center">
-                                    {rp.thumbnail_url ? (
-                                        <img src={blogService.getFileUrl(rp.thumbnail_url)} alt="" className="w-full h-full object-cover" />
-                                    ) : (
-                                        <span className="font-['Onest'] font-bold text-lg text-gray-400">{(rp.title || '?')[0]}</span>
-                                    )}
-                                </div>
-                                <div className="flex flex-col flex-1 min-w-0">
-                                    <span className="font-['Onest'] font-medium text-lg text-[#0a0a0a] line-clamp-1">{rp.title}</span>
-                                    <span className="font-['Onest'] text-xs text-[#737373] line-clamp-2">{rp.excerpt}</span>
-                                </div>
-                            </Link>
-                        ))}
+                        {relatedPosts.map((rp) => {
+                            // Match PostCard's thumbnail logic so related items
+                            // keep the same visual when no explicit thumbnail
+                            // is set but a PDF attachment is available.
+                            const rpThumb = rp.thumbnail_url ? blogService.getFileUrl(rp.thumbnail_url) : null;
+                            const rpPdf = !rpThumb && rp.attachments
+                                ? rp.attachments.find(a => /\.pdf$/i.test(a.filename || a.original_filename || ''))
+                                : null;
+                            const rpPdfUrl = rpPdf ? blogService.getFileUrl(rpPdf.url) : null;
+                            return (
+                                <Link key={rp.id} to={`${backPath}/${rp.id}`}
+                                    className="flex gap-4 items-start no-underline hover:opacity-80 transition-opacity">
+                                    <div className="w-[60px] h-[60px] rounded-lg overflow-hidden bg-gray-200 shrink-0 flex items-center justify-center">
+                                        {rpThumb ? (
+                                            <img src={rpThumb} alt="" className="w-full h-full object-cover" />
+                                        ) : rpPdfUrl ? (
+                                            <PdfCardFill url={rpPdfUrl} />
+                                        ) : (
+                                            <span className="font-['Onest'] font-bold text-lg text-gray-400">{(rp.title || '?')[0]}</span>
+                                        )}
+                                    </div>
+                                    <div className="flex flex-col flex-1 min-w-0">
+                                        <span className="font-['Onest'] font-medium text-lg text-[#0a0a0a] line-clamp-1">{rp.title}</span>
+                                        <span className="font-['Onest'] text-xs text-[#737373] line-clamp-2">{rp.excerpt}</span>
+                                    </div>
+                                </Link>
+                            );
+                        })}
                     </div>
                 </div>
             )}

--- a/src/pages/IndicatorTemplate.jsx
+++ b/src/pages/IndicatorTemplate.jsx
@@ -186,7 +186,7 @@ export default function IndicatorTemplate() {
   const zoomOutIcon = <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2"/><path d="M21 21l-4.3-4.3" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/><path d="M8 11h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>;
   const resetIcon = <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M3 12a9 9 0 1 0 3-6.7M3 4v5h5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg>;
 
-  const [activeChartTool, setActiveChartTool] = useState(null);
+  const [activeChartTool, setActiveChartTool] = useState('selection');
   const [toolDropdownOpen, setToolDropdownOpen] = useState(false);
   const toolDropdownRef = useRef(null);
 
@@ -240,6 +240,7 @@ export default function IndicatorTemplate() {
         zoomHistoryRef.current.push({ min: viewport.min, max: viewport.max });
       }
       setViewport({ min: null, max: null });
+      clickToolbarButton('.apexcharts-reset-icon');
       return true;
     }
 
@@ -270,6 +271,9 @@ export default function IndicatorTemplate() {
       if (zoomHistoryRef.current.length > 0) {
         const prev = zoomHistoryRef.current.pop();
         setViewport(prev);
+        if (prev?.min == null || prev?.max == null) {
+          clickToolbarButton('.apexcharts-reset-icon');
+        }
         return;
       }
       if (applyCappedZoom(2)) return;

--- a/src/pages/IndicatorTemplate.jsx
+++ b/src/pages/IndicatorTemplate.jsx
@@ -132,16 +132,35 @@ export default function IndicatorTemplate() {
   // For horizontal bars the xaxis is the value scale (not time), so viewport
   // can't be applied via xaxis.min/max. Instead, filter categories by the
   // viewport time range here so the chart only receives the visible slice.
-  const chartSeriesData = (allLoadedData || chartData)?.series || [];
-  const visibleSeries = isHorizontalBar && viewport.min != null && viewport.max != null
-    ? chartSeriesData.map(s => ({
-        ...s,
-        data: (s.data || []).filter(p => {
-          const xVal = typeof p.x === 'number' ? p.x : new Date(p.x).getTime();
-          return xVal >= viewport.min && xVal <= viewport.max;
-        }),
-      }))
-    : chartSeriesData;
+  const chartSeriesData = useMemo(
+    () => (allLoadedData || chartData)?.series || [],
+    [allLoadedData, chartData],
+  );
+  // Memoise so the array reference is stable when nothing meaningful changed.
+  // Without this the chart sees a new `series` prop on every parent re-render
+  // (e.g. while the user is panning, the `scrolled` event fires `setViewport`
+  // which re-renders here) and rebuilds itself, tearing down the drag the
+  // user is in the middle of.
+  const visibleSeries = useMemo(() => (
+    isHorizontalBar && viewport.min != null && viewport.max != null
+      ? chartSeriesData.map(s => ({
+          ...s,
+          data: (s.data || []).filter(p => {
+            const xVal = typeof p.x === 'number' ? p.x : new Date(p.x).getTime();
+            return xVal >= viewport.min && xVal <= viewport.max;
+          }),
+        }))
+      : chartSeriesData
+  ), [chartSeriesData, isHorizontalBar, viewport.min, viewport.max]);
+
+  // Final series array handed to the chart. Memoising the .map keeps the
+  // reference stable so the chart's series-keyed useEffect doesn't fire on
+  // every parent render — pan stays alive across viewport state updates.
+  const indicatorName = getName(indicatorData);
+  const chartSeries = useMemo(
+    () => visibleSeries.map(s => ({ ...s, name: s.name || indicatorName })),
+    [visibleSeries, indicatorName],
+  );
 
   const chartCategoryCount = Math.max(
     ...visibleSeries.map(s => (s.data || []).length),
@@ -160,7 +179,6 @@ export default function IndicatorTemplate() {
   };
 
   const chartToolModes = [
-    { value: 'pan', label: t('indicator.chart_tool_pan'), icon: modeIcons.pan },
     { value: 'selection', label: t('indicator.chart_tool_selection'), icon: modeIcons.selection },
   ];
 
@@ -168,7 +186,7 @@ export default function IndicatorTemplate() {
   const zoomOutIcon = <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2"/><path d="M21 21l-4.3-4.3" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/><path d="M8 11h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>;
   const resetIcon = <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M3 12a9 9 0 1 0 3-6.7M3 4v5h5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg>;
 
-  const [activeChartTool, setActiveChartTool] = useState('pan');
+  const [activeChartTool, setActiveChartTool] = useState(null);
   const [toolDropdownOpen, setToolDropdownOpen] = useState(false);
   const toolDropdownRef = useRef(null);
 
@@ -200,7 +218,12 @@ export default function IndicatorTemplate() {
     return { min: Math.min(...xs), max: Math.max(...xs) };
   };
 
-  const applyCappedZoom = (factor) => {
+  // Zoom-history stack: each zoom-in / pan / chart-emitted viewport change
+  // pushes the previous viewport here, so that zoom-out can step back through
+  // the user's path instead of jumping straight to the full data range.
+  const zoomHistoryRef = useRef([]);
+
+  const applyCappedZoom = (factor, recordHistory = false) => {
     const bounds = getDataXBounds();
     if (!bounds || !(bounds.min < bounds.max)) return false;
 
@@ -213,6 +236,9 @@ export default function IndicatorTemplate() {
     const dataRange = bounds.max - bounds.min;
 
     if (newRange >= dataRange) {
+      if (recordHistory && viewport.min != null) {
+        zoomHistoryRef.current.push({ min: viewport.min, max: viewport.max });
+      }
       setViewport({ min: null, max: null });
       return true;
     }
@@ -224,18 +250,31 @@ export default function IndicatorTemplate() {
     if (newMax > bounds.max) { newMin -= newMax - bounds.max; newMax = bounds.max; }
     if (newMin < bounds.min) newMin = bounds.min;
 
+    if (recordHistory) {
+      zoomHistoryRef.current.push({ min: viewport.min, max: viewport.max });
+    }
     setViewport({ min: newMin, max: newMax });
     return true;
   };
 
   const handleChartToolSelect = (tool) => {
     if (tool === 'reset') {
+      zoomHistoryRef.current = [];
       setViewport({ min: null, max: null });
       clickToolbarButton('.apexcharts-reset-icon');
       return;
     }
-    if (tool === 'zoomOut' && applyCappedZoom(2)) return;
-    if (tool === 'zoomIn' && applyCappedZoom(0.5)) return;
+    if (tool === 'zoomOut') {
+      // Prefer stepping back through the user's zoom history; fall back to
+      // a 2× expansion if there's nothing on the stack.
+      if (zoomHistoryRef.current.length > 0) {
+        const prev = zoomHistoryRef.current.pop();
+        setViewport(prev);
+        return;
+      }
+      if (applyCappedZoom(2)) return;
+    }
+    if (tool === 'zoomIn' && applyCappedZoom(0.5, true)) return;
 
     const selectorMap = {
       zoom: '.apexcharts-zoom-icon',
@@ -247,7 +286,10 @@ export default function IndicatorTemplate() {
     const selector = selectorMap[tool];
     if (!selector) return;
     if (['zoom', 'pan', 'selection'].includes(tool)) {
-      setActiveChartTool(tool);
+      // Toggle: clicking the active tool again deselects it (no drag
+      // interaction until the user picks a tool back). Apex's toolbar
+      // toggles the same way, so we mirror the icon click either way.
+      setActiveChartTool(prev => (prev === tool ? null : tool));
     }
     clickToolbarButton(selector);
   };
@@ -261,6 +303,9 @@ export default function IndicatorTemplate() {
     // both flows correct.
     if (isHorizontalBar) return;
     if (newViewport.min !== viewport.min || newViewport.max !== viewport.max) {
+        // Record the previous viewport so the zoom-out button can step back
+        // through chart-driven changes (mouse zoom, pan, selection) too.
+        zoomHistoryRef.current.push({ min: viewport.min, max: viewport.max });
         setViewport(newViewport);
     }
   }, [viewport.min, viewport.max, isHorizontalBar]);
@@ -896,7 +941,7 @@ export default function IndicatorTemplate() {
                         className="text-[#0a0a0a] bg-[#fffefc] border border-[#d4d4d4] rounded-lg p-2 shadow-sm hover:bg-black/[0.02] transition-colors flex items-center gap-1 cursor-pointer"
                         title={t('indicator.chart_tools')}
                       >
-                        {chartSupportsTools ? (modeIcons[activeChartTool === 'zoom' ? 'pan' : activeChartTool] || modeIcons.pan) : zoomInIcon}
+                        {chartSupportsTools ? (modeIcons[activeChartTool] || modeIcons.selection) : zoomInIcon}
                         <svg className={`w-3.5 h-3.5 text-[#0a0a0a] shrink-0 transition-transform ${toolDropdownOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                         </svg>
@@ -987,13 +1032,7 @@ export default function IndicatorTemplate() {
                       chartId={`indicator-${indicatorId}`}
                       chartType={chartType}
                       xaxisType="datetime"
-                      series={visibleSeries.map(s => ({
-                        ...s,
-                        // Each series carries its resource's name; only fall
-                        // back to the indicator name if the resource hasn't
-                        // loaded yet (race with indicatorResources fetch).
-                        name: s.name || getName(indicatorData)
-                      }))}
+                      series={chartSeries}
                       height={chartHeight}
                       showToolbar={true}
                       showLegend={true}
@@ -1083,7 +1122,7 @@ export default function IndicatorTemplate() {
               </div>
             </div>
 
-            {/* Ferramentas (Tools) card — hidden for now
+            {/* Ferramentas (Tools) card */}
             <div className={cardClass}>
               <div className="flex flex-col gap-4">
                 <h3 className="font-['Onest'] font-semibold text-2xl text-[#0a0a0a] tracking-tight">
@@ -1091,7 +1130,7 @@ export default function IndicatorTemplate() {
                 </h3>
 
                 <div className="space-y-4">
-                  {/* Date range * /}
+                  {/* Date range */}
                   <div>
                     <div className="flex flex-col gap-2">
                       <div className="flex items-center gap-4">
@@ -1114,33 +1153,9 @@ export default function IndicatorTemplate() {
                       </div>
                     </div>
                   </div>
-
-                  {/* Interval selector — hidden for now
-                  <div>
-                    <p className="font-['Onest'] font-medium text-sm text-[#0a0a0a] mb-2">{t('indicator.interval', 'Intervalo')}:</p>
-                    <div className="flex">
-                      {[
-                        { label: t('indicator.granularity_day'), value: '1d' },
-                        { label: t('indicator.granularity_month'), value: '1M' },
-                        { label: t('indicator.granularity_year'), value: '1y' },
-                      ].map((option, i, arr) => (
-                        <button
-                          key={option.value}
-                          onClick={() => setUiGranularity(option.value)}
-                          className={`font-['Onest'] font-medium text-sm px-3 py-2 border border-[#e5e5e5] -ml-px first:ml-0 transition-colors cursor-pointer
-                            ${i === 0 ? 'rounded-l-lg' : ''} ${i === arr.length - 1 ? 'rounded-r-lg' : ''}
-                            ${uiGranularity === option.value ? 'bg-black/[0.03] border-[#d4d4d4] text-[#0a0a0a]' : 'bg-transparent text-[#0a0a0a]'}`}
-                        >
-                          {option.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  * /}
-
                 </div>
 
-                {/* Reset button * /}
+                {/* Reset button */}
                 <button
                   onClick={handleResetFilters}
                   className="w-full font-['Onest'] font-medium text-base text-[#0a0a0a] border border-[#d4d4d4] rounded-full py-2 shadow-sm hover:bg-black/[0.02] transition-colors cursor-pointer"
@@ -1149,7 +1164,6 @@ export default function IndicatorTemplate() {
                 </button>
               </div>
             </div>
-            */}
 
             {/* Opções (Options) card */}
             <div className={cardClass}>

--- a/src/pages/PublicationsPage.jsx
+++ b/src/pages/PublicationsPage.jsx
@@ -60,7 +60,7 @@ function FeaturedPublication({ post: rawPost, catName }) {
                         {post.title}
                     </h2>
                     {post.excerpt && (
-                        <p className="font-['Onest'] font-medium text-lg text-[#0a0a0a] leading-normal line-clamp-3">
+                        <p className="font-['Onest'] font-medium text-lg text-[#0a0a0a] leading-normal line-clamp-3 whitespace-pre-line">
                             {post.excerpt}
                         </p>
                     )}

--- a/src/utils/chartSeries.js
+++ b/src/utils/chartSeries.js
@@ -250,6 +250,26 @@ export const buildChartSeries = (
   const trans = seriesTranslations && typeof seriesTranslations === 'object'
     ? seriesTranslations
     : null;
+  // Count how many rawSeries each resource contributes. A multi-column file
+  // emits one rawSeries per column, all under the same resource_id; for
+  // those we prefer the column name in the legend so the user can tell the
+  // lines apart. Single-column resources fall back to the file name.
+  const seriesCountByResource = new Map();
+  for (const s of rawSeries) {
+    if (s?.resource_id) {
+      seriesCountByResource.set(s.resource_id, (seriesCountByResource.get(s.resource_id) || 0) + 1);
+    }
+  }
+  // Resource names are stored as "<indicator name> - <file.ext>" by the
+  // upload flow (ResourceWizard). Extract the trailing file name as the
+  // friendly default legend.
+  const extractFileName = (resourceName) => {
+    if (!resourceName || typeof resourceName !== 'string') return null;
+    const idx = resourceName.lastIndexOf(' - ');
+    if (idx < 0) return resourceName.trim() || null;
+    const tail = resourceName.slice(idx + 3).trim();
+    return tail || null;
+  };
   // Composed indicators: when the response contains lines from more than one
   // source indicator we prefix each line's name with the source indicator's
   // localized name so the user can tell them apart. For a non-composed
@@ -264,38 +284,75 @@ export const buildChartSeries = (
     if (lang === 'en') return s.source_indicator_name_en || s.source_indicator_name || '';
     return s.source_indicator_name || s.source_indicator_name_en || '';
   };
+  // Merge rawSeries entries that represent the same logical line. Two
+  // entries are considered the same line when they come from the same source
+  // indicator AND share the same (non-empty) series label — that's the
+  // typical "one indicator, one column, two resources covering different
+  // year ranges" case. Without this the chart would render two disjoint
+  // segments and double up the legend; users expect a single continuous
+  // line under the column's name.
+  //
+  // When the series_label is absent the rawSeries entries can't be matched
+  // on column identity, so we fall back to one line per resource — the
+  // legacy "different files = different streams" behavior.
+  const pickLabel = (s) => (lang === 'en' && s.series_label_en) ? s.series_label_en : s.series_label;
+  const groups = new Map();
+  for (const s of rawSeries) {
+    const label = pickLabel(s);
+    const groupKey = label
+      ? `${s.source_indicator_id || ''}|${label}`
+      : `r:${s.resource_id}|${s.source_indicator_id || ''}`;
+    if (!groups.has(groupKey)) groups.set(groupKey, []);
+    groups.get(groupKey).push(s);
+  }
   return {
-    series: rawSeries.map((s) => {
-      const resource = resById.get(s.resource_id);
-      const label = (lang === 'en' && s.series_label_en) ? s.series_label_en : s.series_label;
+    series: Array.from(groups.values()).map((entries) => {
+      const first = entries[0];
+      const label = pickLabel(first);
       const localized = label && trans && trans[label]
         ? (trans[label][lang] || trans[label][lang === 'pt' ? 'en' : 'pt'])
         : null;
-      const sourceName = pickSourceName(s);
-      // Base name precedence: translated series label → raw label → resource
-      // name → source indicator name → resource_id (fallback while resource
-      // list is still loading).
+      const sourceName = pickSourceName(first);
+      // Only fall back to the file name when (a) the group represents a
+      // single rawSeries entry (no resources were merged) AND (b) that
+      // resource contributes a single column overall. Either condition
+      // failing means we'd be arbitrarily picking one file's name for what
+      // is really many — defer to the column label instead.
+      const singleEntry = entries.length === 1;
+      const resourceSeriesCount = seriesCountByResource.get(first.resource_id) || 0;
+      const fileName = (singleEntry && resourceSeriesCount === 1)
+        ? extractFileName(resById.get(first.resource_id)?.name)
+        : null;
       const baseName = (localized && localized.trim())
+        || fileName
         || label
-        || resource?.name
         || sourceName
-        || s.resource_id;
+        || first.resource_id;
       const name = showSourcePrefix && sourceName && baseName !== sourceName
         ? `${sourceName} — ${baseName}`
         : baseName;
+      // Concatenate every entry's points, normalise x to ms, then sort
+      // ascending so two resources covering adjacent year ranges render as
+      // one continuous line with no internal gap.
+      const data = entries
+        .flatMap((s) => (s.points || []).map((p) => ({
+          x: typeof p.x === 'string' ? new Date(p.x).getTime() : p.x,
+          y: Number(p.y),
+        })))
+        .filter((p) => !Number.isNaN(p.x) && !Number.isNaN(p.y))
+        .sort((a, b) => a.x - b.x);
       return {
         name,
-        resource_id: s.resource_id,
+        // Carry through the *first* resource_id so existing per-series
+        // hooks (export, hidden_series filter) still match by it. The full
+        // resource list is preserved on `resource_ids` for callers that
+        // need to know every contributor.
+        resource_id: first.resource_id,
+        resource_ids: entries.map((s) => s.resource_id).filter(Boolean),
         series_label: label || null,
-        source_indicator_id: s.source_indicator_id || null,
+        source_indicator_id: first.source_indicator_id || null,
         source_indicator_name: sourceName || null,
-        data: (s.points || [])
-          .map((p) => ({
-            // Backend serialises datetime x as ISO; numeric x stays numeric.
-            x: typeof p.x === 'string' ? new Date(p.x).getTime() : p.x,
-            y: Number(p.y),
-          }))
-          .filter((p) => !Number.isNaN(p.x) && !Number.isNaN(p.y)),
+        data,
       };
     }),
   };

--- a/src/utils/chartSeries.test.js
+++ b/src/utils/chartSeries.test.js
@@ -148,6 +148,43 @@ test('buildChartSeries: multi-column file — series_label takes priority over r
   assert.deepEqual(new Set(out.series.map((s) => s.resource_id)), new Set(['r1']));
 });
 
+test('buildChartSeries: complementary year ranges — merges resources sharing a series label', () => {
+  // Two resources covering different time windows for the SAME column collapse
+  // into one continuous line. Without merging the chart used to render two
+  // disjoint segments with both filenames in the legend; users expect a single
+  // series under the column name.
+  const raw = [
+    {
+      resource_id: 'r-old',
+      series_label: 'Valor',
+      points: [
+        { x: '2020-01-01T00:00:00', y: 10 },
+        { x: '2021-01-01T00:00:00', y: 11 },
+        { x: '2022-01-01T00:00:00', y: 12 },
+      ],
+    },
+    {
+      resource_id: 'r-new',
+      series_label: 'Valor',
+      points: [
+        { x: '2023-01-01T00:00:00', y: 13 },
+        { x: '2024-01-01T00:00:00', y: 14 },
+      ],
+    },
+  ];
+  const resources = [
+    { id: 'r-old', name: 'Indicator - INE-2020-2022.xlsx' },
+    { id: 'r-new', name: 'Indicator - INE-2023-2024.xlsx' },
+  ];
+  const out = buildChartSeries(raw, resources);
+  assert.equal(out.series.length, 1);
+  assert.equal(out.series[0].name, 'Valor');
+  assert.equal(out.series[0].data.length, 5);
+  // Sorted ascending so the line is continuous across the boundary.
+  assert.deepEqual(out.series[0].data.map((d) => d.y), [10, 11, 12, 13, 14]);
+  assert.deepEqual(out.series[0].resource_ids, ['r-old', 'r-new']);
+});
+
 test('buildChartSeries: falls back to resource_id when both name and series_label are missing', () => {
   // Race condition: /series response arrives before resources are loaded.
   const out = buildChartSeries(


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the UI components, focusing on chart interaction performance, blog post form handling, API configuration consistency, and enhanced multilingual support in the resource wizard. The main changes include a major fix to chart panning behavior, improved handling of publication dates in blog posts, and support for English names in indicator compositions.

**Chart interaction and performance improvements:**

- Implemented an imperative approach to updating the x-axis range in `GChart` to fix broken pan gestures and prevent unnecessary chart rebuilds during drag operations. The dependency array for the main chart effect was also adjusted to avoid unwanted re-renders, and the `activeTool` prop now allows `null` as a value. [[1]](diffhunk://#diff-c95ab27b87eb535de647cc203577cdf8d347e9cbd64b5c1255d1c3667820307eR329-R360) [[2]](diffhunk://#diff-c95ab27b87eb535de647cc203577cdf8d347e9cbd64b5c1255d1c3667820307eL1250-R1297) [[3]](diffhunk://#diff-c95ab27b87eb535de647cc203577cdf8d347e9cbd64b5c1255d1c3667820307eL1292-R1339)
- Fixed a bug in annotation hit-testing by ensuring only `Node` objects are checked with `contains`, preventing runtime errors from `Window` objects in the event path.

**Blog post form enhancements:**

- Added logic to lock the `published_at` date after post creation, ensuring edits do not change the original publication date. The date is now only set at creation, and is omitted from update payloads. [[1]](diffhunk://#diff-f686322f91741a86337310a318bed319325989cf914a0b4fa762efa3f039fb7bL260-R265) [[2]](diffhunk://#diff-f686322f91741a86337310a318bed319325989cf914a0b4fa762efa3f039fb7bL323-R328) [[3]](diffhunk://#diff-f686322f91741a86337310a318bed319325989cf914a0b4fa762efa3f039fb7bL397-R406) [[4]](diffhunk://#diff-f686322f91741a86337310a318bed319325989cf914a0b4fa762efa3f039fb7bL684-R709)

**Resource wizard and indicator composition improvements:**

- Added support for an English name field (`name_en`) in indicator compositions, including UI input, state management, prop types, and summary display. This is reflected in both the composition builder and the resource wizard. [[1]](diffhunk://#diff-cddef2572404f255de4b06bc28e0f9aad6e6f65285f2319edd9e53a9e599cfdcR68) [[2]](diffhunk://#diff-cddef2572404f255de4b06bc28e0f9aad6e6f65285f2319edd9e53a9e599cfdcL90-R92) [[3]](diffhunk://#diff-cddef2572404f255de4b06bc28e0f9aad6e6f65285f2319edd9e53a9e599cfdcR105-R117) [[4]](diffhunk://#diff-cddef2572404f255de4b06bc28e0f9aad6e6f65285f2319edd9e53a9e599cfdcR239) [[5]](diffhunk://#diff-f65bf06d8470f645cde6b1caa8a6f8a60ec49effa23c7bd916a7366cd7b6100aR65) [[6]](diffhunk://#diff-f65bf06d8470f645cde6b1caa8a6f8a60ec49effa23c7bd916a7366cd7b6100aR621) [[7]](diffhunk://#diff-f65bf06d8470f645cde6b1caa8a6f8a60ec49effa23c7bd916a7366cd7b6100aR1062-R1069)
- Updated indicator fetch calls to include a new parameter for getting only published indicators, improving the relevance of indicator selection in the composition builder and picker. [[1]](diffhunk://#diff-cddef2572404f255de4b06bc28e0f9aad6e6f65285f2319edd9e53a9e599cfdcL35-R35) [[2]](diffhunk://#diff-7feb25e87a5df05fb8f734c046aafb0c9eb2d643f107dba7118f909486235b03L58-R59)

**API configuration consistency:**

- Changed the default and placeholder value for the `api_key_header` field from `'X-API-Key'` to `'api-key'` in both the API config form and the resource wizard, ensuring consistency across the UI. [[1]](diffhunk://#diff-fac2cc59e821ab5ee75bdee87e0ede19a3953b104f7326d182bfae1bf2c78686L9-R9) [[2]](diffhunk://#diff-fac2cc59e821ab5ee75bdee87e0ede19a3953b104f7326d182bfae1bf2c78686L114-R114) [[3]](diffhunk://#diff-f65bf06d8470f645cde6b1caa8a6f8a60ec49effa23c7bd916a7366cd7b6100aL74-R75)

**UI/UX refinements:**

- Improved text rendering for post excerpts by using `whitespace-pre-line` to preserve line breaks in both `PostCard` and `FeaturedPost` components. [[1]](diffhunk://#diff-cddcbbe047d7f47a8f47f073185b6adcf7da39e56ada5c5b8d26d2e55c34216bL46-R46) [[2]](diffhunk://#diff-d6e4e143ce03a0a160a303e0ec2ed8cc5459417da7c3478f7623ccab991baeb4L47-R47)
- Ensured consistent navbar layout in the weather component by reserving width for the widest city label, preventing layout shifts as city names rotate.