### PR TITLE
fix texts

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -846,14 +846,13 @@
       "title": "Networks & Certifications",
       "intro": "ROOTS promotes collaboration with various institutions linked to tourism, research, and territorial development. Key institutional partners include:",
       "conhecimento_title": "Knowledge Networks",
-      "conhecimento_p1": "ROOTS seeks to integrate knowledge-sharing networks related to sustainable tourism monitoring.",
-      "conhecimento_p2": "Coming soon.",
-      "coming_soon": "Coming soon",
+      "conhecimento_p1": "ROOTS seeks to integrate knowledge-sharing networks related to sustainable tourism monitoring. Among these is the International Network of Sustainable Tourism Observatories, promoted by UN Tourism.",
       "iniciativas_title": "Initiatives & Certifications",
       "iniciativas_intro": "The Observatory follows and promotes initiatives related to sustainability and innovation in tourism, including:",
       "iniciativas_item1": "Monitoring sustainability indicators",
       "iniciativas_item2": "Applied research projects",
-      "iniciativas_item3": "Certification and best practice programmes"
+      "iniciativas_item3": "Certification and best practice programmes",
+      "iniciativas_item4": "[Local certifications or initiatives]"
     },
     "nav": {
       "quem_somos": "Who are we?",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -846,14 +846,13 @@
       "title": "Redes e Certificações",
       "intro": "A ROOTS promove a colaboração com diferentes instituições ligadas ao turismo, à investigação e ao desenvolvimento territorial. Entre os parceiros institucionais destacam-se:",
       "conhecimento_title": "Redes de Conhecimento",
-      "conhecimento_p1": "A ROOTS procura integrar redes de partilha de conhecimento relacionadas com a monitorização do turismo sustentável.",
-      "conhecimento_p2": "Em breve.",
-      "coming_soon": "Em breve",
+      "conhecimento_p1": "A ROOTS procura integrar redes de partilha de conhecimento relacionadas com a monitorização do turismo sustentável. Entre estas destaca-se a International Network of Sustainable Tourism Observatories, promovida pela UN Tourism.",
       "iniciativas_title": "Iniciativas e Certificações",
       "iniciativas_intro": "O Observatório acompanha e promove iniciativas relacionadas com a sustentabilidade e inovação no turismo, incluindo:",
       "iniciativas_item1": "Monitorização de indicadores de sustentabilidade",
       "iniciativas_item2": "Projetos de investigação aplicada",
-      "iniciativas_item3": "Programas de certificação e boas práticas"
+      "iniciativas_item3": "Programas de certificação e boas práticas",
+      "iniciativas_item4": "[Certificações ou iniciativas locais]"
     },
     "nav": {
       "quem_somos": "Quem somos?",

--- a/src/pages/roots/RedesCertificacoes.jsx
+++ b/src/pages/roots/RedesCertificacoes.jsx
@@ -16,11 +16,6 @@ export default function RedesCertificacoes() {
             <p className="text-base md:text-lg lg:text-2xl leading-relaxed text-base-content">
               {t('roots.redes.intro')}
             </p>
-            <div className="flex flex-wrap items-center gap-6 md:gap-10 mt-2">
-              <span className="text-base md:text-lg lg:text-2xl italic text-base-content/60">
-                {t('roots.redes.coming_soon')}
-              </span>
-            </div>
           </div>
           <img
             src="/assets/roots/redes-hero.png"
@@ -43,9 +38,6 @@ export default function RedesCertificacoes() {
             <p className="text-base md:text-lg lg:text-2xl leading-relaxed text-base-content">
               {t('roots.redes.conhecimento_p1')}
             </p>
-            <p className="text-base md:text-lg lg:text-2xl leading-relaxed italic text-base-content/60">
-              {t('roots.redes.conhecimento_p2')}
-            </p>
           </div>
         </section>
 
@@ -62,6 +54,7 @@ export default function RedesCertificacoes() {
               <li>{t('roots.redes.iniciativas_item1')}</li>
               <li>{t('roots.redes.iniciativas_item2')}</li>
               <li>{t('roots.redes.iniciativas_item3')}</li>
+              <li>{t('roots.redes.iniciativas_item4')}</li>
             </ul>
           </div>
           <img

--- a/src/pages/roots/Territorio.jsx
+++ b/src/pages/roots/Territorio.jsx
@@ -17,9 +17,6 @@ export default function Territorio() {
               <p className="text-base md:text-lg lg:text-2xl leading-[1.5] text-[#0a0a0a]">
                 {t('roots.territorio.area_p1')}
               </p>
-              <p className="text-base md:text-lg lg:text-2xl leading-[1.5] text-[#0a0a0a]">
-                {t('roots.territorio.area_p2')}
-              </p>
             </div>
             <div className="w-full max-w-[445px] aspect-square shrink-0 mx-auto lg:mx-0">
               <img


### PR DESCRIPTION
This pull request updates the "Networks & Certifications" section for both English and Portuguese locales and their corresponding UI components. The main goal is to provide more specific information about knowledge networks and initiatives, removing placeholder "coming soon" messages, and adding new items to the initiatives list.

**Localization and Content Updates:**

* Added specific mention of the International Network of Sustainable Tourism Observatories (promoted by UN Tourism) to the `conhecimento_p1` field in both English and Portuguese translations, replacing generic placeholder text. [[1]](diffhunk://#diff-8e77946ee485378b13babd5fe6bdc1707b77dce605ac6723d7a5b4494dc94925L849-R855) [[2]](diffhunk://#diff-1366ca17680a8c84ec8eacc6393a5a926326cf58687cc51f78d06a955e55a519L849-R855)
* Added a new item for local certifications or initiatives (`iniciativas_item4`) in both translation files. [[1]](diffhunk://#diff-8e77946ee485378b13babd5fe6bdc1707b77dce605ac6723d7a5b4494dc94925L849-R855) [[2]](diffhunk://#diff-1366ca17680a8c84ec8eacc6393a5a926326cf58687cc51f78d06a955e55a519L849-R855)

**UI and Component Adjustments:**

* Removed "coming soon" placeholder UI elements from the `RedesCertificacoes` page, so users now see the updated content directly. [[1]](diffhunk://#diff-52da49930264905e00726b68bfba3038d4bfa0ac9bed9c53c42c78d663aa527eL19-L23) [[2]](diffhunk://#diff-52da49930264905e00726b68bfba3038d4bfa0ac9bed9c53c42c78d663aa527eL46-L48)
* Updated the initiatives list in `RedesCertificacoes` to include the new local certifications or initiatives item.
* Removed a redundant paragraph from the `Territorio` page that previously displayed placeholder content.