### PR TITLE
fix

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -496,7 +496,9 @@
       "step_columns_desc": "Activate/deactivate columns and adjust PT/EN translations. Pre-filled values come from the auto-translator and are editable.",
       "column_label_pt": "Label (PT)",
       "column_label_en": "Label (EN)",
-      "column_hidden_badge": "hidden"
+      "column_hidden_badge": "hidden",
+      "show_time_averages": "Show time averages",
+      "show_time_averages_desc": "Shows the average buttons (raw, hourly, daily, annual) on the indicator page. Disable for environmental indicators such as CO, O3, noise and rainfall."
     },
     "area": {
       "title_new": "New Area",
@@ -779,7 +781,11 @@
     "chart_tool_zoom_out": "Zoom out",
     "chart_tool_reset": "Reset zoom",
     "sources_load_partial": "Failed to load {{count}} of {{total}} source(s).",
-    "sources_load_failed": "Failed to load sources. The resource service may be unreachable."
+    "sources_load_failed": "Failed to load sources. The resource service may be unreachable.",
+    "granularity_auto": "Auto",
+    "granularity_hourly": "Hourly",
+    "granularity_daily": "Daily",
+    "granularity_annual": "Annual"
   },
   "chart_types": {
     "line": "Line",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -496,7 +496,9 @@
       "step_columns_desc": "Ative/desative colunas e ajuste as traduções PT/EN. As traduções pré-preenchidas vêm do tradutor automático e podem ser editadas.",
       "column_label_pt": "Etiqueta (PT)",
       "column_label_en": "Etiqueta (EN)",
-      "column_hidden_badge": "oculta"
+      "column_hidden_badge": "oculta",
+      "show_time_averages": "Mostrar médias temporais",
+      "show_time_averages_desc": "Mostra os botões de média (raw, horário, diário, anual) na página do indicador. Desative para indicadores ambientais como CO, O3, ruído e pluviosidade."
     },
     "area": {
       "title_new": "Novo Área",
@@ -779,7 +781,11 @@
     "chart_tool_zoom_out": "Reduzir",
     "chart_tool_reset": "Repor zoom",
     "sources_load_partial": "Falha ao carregar {{count}} de {{total}} fonte(s).",
-    "sources_load_failed": "Falha ao carregar fontes. O serviço de recursos pode estar inacessível."
+    "sources_load_failed": "Falha ao carregar fontes. O serviço de recursos pode estar inacessível.",
+    "granularity_auto": "Auto",
+    "granularity_hourly": "Horário",
+    "granularity_daily": "Diário",
+    "granularity_annual": "Anual"
   },
   "chart_types": {
     "line": "Linha",

--- a/src/components/admin/AuthorFormModal.jsx
+++ b/src/components/admin/AuthorFormModal.jsx
@@ -18,7 +18,7 @@ import blogService from '../../services/blogService';
 const EMPTY = {
   nome: '', apelido: '', email: '',
   description: '', description_en: '',
-  institution: '', role: '',
+  institution: '', role: '', role_en: '',
   orcid: '', scopus: '', researchgate: '', linkedin: '',
 };
 
@@ -63,6 +63,7 @@ export default function AuthorFormModal({ onClose, author = null, onSaved }) {
         apelido: parts.length > 1 ? parts[parts.length - 1] : '',
         email: author.email || '',
         role: author.role || '',
+        role_en: author.role_en || '',
         orcid: author.orcid || '',
         linkedin: author.linkedin || '',
       });
@@ -127,6 +128,7 @@ export default function AuthorFormModal({ onClose, author = null, onSaved }) {
       name: `${data.nome.trim()} ${data.apelido.trim()}`.trim(),
       email: data.email.trim() || undefined,
       role: data.role.trim() || undefined,
+      role_en: data.role_en.trim() || undefined,
       orcid: data.orcid.trim() || undefined,
       linkedin: data.linkedin.trim() || undefined,
     };
@@ -283,7 +285,13 @@ export default function AuthorFormModal({ onClose, author = null, onSaved }) {
             <SectionTitle>{t('admin.authors.section_affiliation', 'Afiliação')}</SectionTitle>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
               <FormInput label={t('admin.authors.institution', 'Instituição')} name="author_institution" value={data.institution} onChange={set('institution')} placeholder="Ex. Universidade de Aveiro" />
-              <FormInput label={t('admin.authors.role', 'Cargo')} name="author_role" value={data.role} onChange={set('role')} placeholder="Ex. Investigadora" />
+              <FormInput
+                label={`${t('admin.authors.role', 'Cargo')}${lang === 'en' ? ' (EN)' : ''}`}
+                name={lang === 'pt' ? 'author_role' : 'author_role_en'}
+                value={lang === 'pt' ? data.role : data.role_en}
+                onChange={set(lang === 'pt' ? 'role' : 'role_en')}
+                placeholder="Ex. Investigadora"
+              />
             </div>
           </div>
 

--- a/src/components/admin/IndicatorFormPanel.jsx
+++ b/src/components/admin/IndicatorFormPanel.jsx
@@ -5,11 +5,13 @@ import { LuX, LuFileText } from 'react-icons/lu';
 import FormInput from '../forms/FormInput';
 import FormTextarea from '../forms/FormTextarea';
 import FormSelect from '../forms/FormSelect';
+import FormCheckbox from '../forms/FormCheckbox';
 import SuccessModal from '../wizard/SuccessModal';
+import ChartTypePreview from '../wizard/ChartTypePreview';
 import useSlideOver from '../../hooks/useSlideOver';
 import indicatorService from '../../services/indicatorService';
 import areaService from '../../services/areaService';
-import { DEFAULT_CHART_TYPES, DEFAULT_CHART_TYPE } from '../../constants/chartTypes';
+import { CHART_TYPES, CHART_TYPE_LABEL_KEYS, DEFAULT_CHART_TYPES, DEFAULT_CHART_TYPE } from '../../constants/chartTypes';
 
 // Right-half create/edit panel for an indicator (Figma nodes 2871:12370 /
 // 2898:16176). Renders over the indicators list, occupying ~half the screen.
@@ -17,6 +19,9 @@ const EMPTY = {
   name: '', name_en: '', description: '', description_en: '',
   area: '', dimension: '', unit: '', unit_en: '',
   scale: '', scale_en: '', font: '', font_en: '', governance: false,
+  carrying_capacity_enabled: false, carrying_capacity: '',
+  show_time_averages: true,
+  chart_types: [...DEFAULT_CHART_TYPES], default_chart_type: DEFAULT_CHART_TYPE,
   status: 'published',
 };
 
@@ -52,6 +57,12 @@ export default function IndicatorFormPanel({ indicatorId = null, onClose, onSave
               scale: ind.scale || '', scale_en: ind.scale_en || '',
               font: ind.font || '', font_en: ind.font_en || '',
               governance: ind.governance || false,
+              carrying_capacity_enabled: ind.carrying_capacity != null && ind.carrying_capacity !== '',
+              carrying_capacity: ind.carrying_capacity ?? '',
+              show_time_averages: ind.show_time_averages !== false,
+              chart_types: Array.isArray(ind.chart_types) && ind.chart_types.length > 0
+                ? ind.chart_types : [...DEFAULT_CHART_TYPES],
+              default_chart_type: ind.default_chart_type || DEFAULT_CHART_TYPE,
               status: ind.status || 'published',
             });
           }
@@ -74,6 +85,21 @@ export default function IndicatorFormPanel({ indicatorId = null, onClose, onSave
 
   const set = (key) => (value) => setData(prev => ({ ...prev, [key]: value }));
 
+  // Toggle a chart type in/out of the allowed set, keeping default_chart_type
+  // consistent: if the current default gets removed, fall back to the first
+  // remaining type; if nothing was selected as default yet, adopt the first.
+  const toggleChartType = (type) => {
+    setData(prev => {
+      const current = prev.chart_types || [];
+      const has = current.includes(type);
+      const next = has ? current.filter(t => t !== type) : [...current, type];
+      let def = prev.default_chart_type;
+      if (has && def === type) def = next[0] || '';
+      else if (!def && next.length > 0) def = next[0];
+      return { ...prev, chart_types: next, default_chart_type: def };
+    });
+  };
+
   const selectedArea = areas.find(a => a.id === data.area);
   const dimensionOptions = (() => {
     const subs = selectedArea?.dimensions || selectedArea?.subdomains || selectedArea?.subdominios || [];
@@ -85,6 +111,11 @@ export default function IndicatorFormPanel({ indicatorId = null, onClose, onSave
     if (!data.name.trim()) e.name = t('validation.required', { field: t('wizard.indicator.name_pt', 'Nome'), defaultValue: 'Campo obrigatório' });
     if (!data.area) e.area = t('validation.required', { field: t('wizard.indicator.area', 'Área'), defaultValue: 'Campo obrigatório' });
     if (!data.dimension) e.dimension = t('validation.required', { field: t('wizard.indicator.dimension', 'Dimensão'), defaultValue: 'Campo obrigatório' });
+    if (!data.chart_types || data.chart_types.length === 0) {
+      e.chart_types = t('wizard.indicator.chart_types_required', 'Selecione pelo menos um tipo de gráfico');
+    } else if (!data.chart_types.includes(data.default_chart_type)) {
+      e.default_chart_type = t('wizard.indicator.default_chart_type_invalid', 'O gráfico predefinido tem de estar entre os selecionados');
+    }
     setErrors(e);
     return Object.keys(e).length === 0;
   };
@@ -98,6 +129,12 @@ export default function IndicatorFormPanel({ indicatorId = null, onClose, onSave
       scale: data.scale.trim(), scale_en: data.scale_en.trim(),
       font: data.font.trim(), font_en: data.font_en.trim(),
       governance: data.governance,
+      carrying_capacity: data.carrying_capacity_enabled && data.carrying_capacity !== ''
+        ? Number(data.carrying_capacity)
+        : null,
+      show_time_averages: data.show_time_averages,
+      chart_types: data.chart_types,
+      default_chart_type: data.default_chart_type,
     };
     try {
       setSaving(true);
@@ -119,8 +156,6 @@ export default function IndicatorFormPanel({ indicatorId = null, onClose, onSave
         saved = await indicatorService.create(data.area, data.dimension, {
           ...payload,
           favourites: 0,
-          chart_types: [...DEFAULT_CHART_TYPES],
-          default_chart_type: DEFAULT_CHART_TYPE,
           hidden_series: [],
           series_translations: {},
           // Draft vs published lifecycle. Drafts skip the public listings
@@ -237,6 +272,77 @@ export default function IndicatorFormPanel({ indicatorId = null, onClose, onSave
                     checked={data.governance} onChange={(e) => set('governance')(e.target.checked)} />
                   <span className="font-medium text-[17px] text-[#0a0a0a]">{t('admin.indicators.col_governance', 'Governança')}</span>
                 </label>
+
+                <FormCheckbox
+                  label={t('wizard.indicator.carrying_capacity', 'Capacidade de carga')}
+                  name="carrying_capacity_enabled"
+                  checked={data.carrying_capacity_enabled}
+                  onChange={(checked) => set('carrying_capacity_enabled')(checked)}
+                  description={t('wizard.indicator.carrying_capacity_desc', 'Define um limite de referência para o indicador.')}
+                />
+                {data.carrying_capacity_enabled && (
+                  <FormInput
+                    label={t('wizard.indicator.carrying_capacity_value', 'Valor da capacidade de carga')}
+                    name="carrying_capacity"
+                    type="number"
+                    value={data.carrying_capacity}
+                    onChange={set('carrying_capacity')}
+                    placeholder={t('wizard.indicator.carrying_capacity_placeholder', 'Ex. 1000')}
+                  />
+                )}
+
+                <FormCheckbox
+                  label={t('wizard.indicator.show_time_averages', 'Mostrar médias temporais')}
+                  name="show_time_averages"
+                  checked={data.show_time_averages}
+                  onChange={(checked) => set('show_time_averages')(checked)}
+                  description={t('wizard.indicator.show_time_averages_desc', 'Mostra os botões de média (raw, horário, diário, anual) na página do indicador. Desative para indicadores ambientais como CO, O3, ruído e pluviosidade.')}
+                />
+              </div>
+
+              {/* Chart types */}
+              <div className="flex flex-col gap-6">
+                <div className="flex flex-col gap-2">
+                  <h3 className="font-medium text-[24px] text-[#0a0a0a]">{t('wizard.indicator.step_charts', 'Gráficos')}</h3>
+                  <div className="h-px w-full bg-[#e5e5e5]" />
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <p className="font-medium text-[15px] text-[#0a0a0a]">{t('wizard.indicator.chart_types_label', 'Tipos de gráfico disponíveis')}</p>
+                  <p className="text-[13px] text-[#737373]">{t('wizard.indicator.chart_types_hint', 'Escolha quais os gráficos que podem ser mostrados neste indicador.')}</p>
+                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-1">
+                    {CHART_TYPES.map(type => {
+                      const checked = (data.chart_types || []).includes(type);
+                      return (
+                        <label key={type}
+                          className={`flex flex-col gap-2 cursor-pointer border rounded-lg p-2 transition-colors ${checked ? 'border-[#009368] bg-[#009368]/5' : 'border-[#e5e5e5] hover:border-[#d4d4d4]'}`}>
+                          <div className="flex items-center gap-2">
+                            <input type="checkbox" className="w-[18px] h-[18px] rounded border-[#d4d4d4] accent-[#009368]"
+                              checked={checked} onChange={() => toggleChartType(type)} />
+                            <span className="text-[14px] font-medium text-[#0a0a0a]">{t(CHART_TYPE_LABEL_KEYS[type])}</span>
+                          </div>
+                          <div className="w-full h-[90px] bg-white rounded overflow-hidden">
+                            <ChartTypePreview chartType={type} data={[]} height={90} />
+                          </div>
+                        </label>
+                      );
+                    })}
+                  </div>
+                  {errors.chart_types && <p className="text-[13px] text-[#dc2626]">{errors.chart_types}</p>}
+                </div>
+
+                <FormSelect
+                  label={t('wizard.indicator.default_chart_type_label', 'Gráfico predefinido')}
+                  name="default_chart_type"
+                  value={data.default_chart_type || ''}
+                  onChange={set('default_chart_type')}
+                  options={(data.chart_types || []).map(type => ({ value: type, label: t(CHART_TYPE_LABEL_KEYS[type]) }))}
+                  placeholder={t('wizard.indicator.default_chart_type_placeholder', 'Selecionar gráfico predefinido')}
+                  required
+                  error={errors.default_chart_type}
+                  disabled={(data.chart_types || []).length === 0}
+                />
+                <p className="text-[13px] text-[#737373] -mt-3">{t('wizard.indicator.default_chart_type_hint', 'É o gráfico mostrado por omissão na página do indicador.')}</p>
               </div>
             </div>
           )}

--- a/src/pages/AuthorPage.jsx
+++ b/src/pages/AuthorPage.jsx
@@ -109,6 +109,7 @@ export default function AuthorPage() {
 
     // Derive unique category slugs from the author's posts for filter pills
     const lang = i18n.language?.startsWith('en') ? 'en' : 'pt'
+    const authorRole = (lang === 'en' && author?.role_en) ? author.role_en : author?.role
     const postCatSlugs = [...new Set(posts.flatMap(p => p.categories || []))]
     const catSlugs = postCatSlugs.filter(slug => categories.some(c => c.slug === slug))
     const catName = (slug) => {
@@ -172,9 +173,9 @@ export default function AuthorPage() {
                                 <h1 className="font-['Onest'] font-semibold text-3xl text-[#0a0a0a] tracking-tight text-center">
                                     {author.name}
                                 </h1>
-                                {author.role && (
+                                {authorRole && (
                                     <p className="font-['Onest'] font-medium text-base text-[#737373] text-center">
-                                        {author.role}
+                                        {authorRole}
                                     </p>
                                 )}
                                 {socialLinks.length > 0 && (
@@ -360,9 +361,9 @@ export default function AuthorPage() {
                             <h1 className="font-['Onest'] font-semibold text-4xl text-[#0a0a0a] tracking-tight mt-4 text-center">
                                 {author.name}
                             </h1>
-                            {author.role && (
+                            {authorRole && (
                                 <p className="font-['Onest'] font-medium text-lg text-[#737373] mt-1 text-center">
-                                    {author.role}
+                                    {authorRole}
                                 </p>
                             )}
                             {socialLinks.length > 0 && (

--- a/src/pages/BlogPostForm.jsx
+++ b/src/pages/BlogPostForm.jsx
@@ -247,6 +247,7 @@ export default function BlogPostForm({ onClose = () => {}, onSaved = () => {}, p
         status: 'draft',
         categories: [],
         keywords: [],
+        keywords_en: [],
         tags: [],
         // Local 'YYYY-MM-DD' chosen at create time; converted to ISO before
         // sending to the backend. On edit we load the existing date here for
@@ -315,7 +316,7 @@ export default function BlogPostForm({ onClose = () => {}, onSaved = () => {}, p
                 title: '', title_en: '', content: '', content_en: '', excerpt: '', excerpt_en: '',
                 author: '', author_id: '', author_photo: '', author_role: '', post_type: routePostType,
                 publication_link: '', publication_link_label: '', publication_link_label_en: '',
-                status: 'draft', categories: [], keywords: [], tags: [], published_at: ''
+                status: 'draft', categories: [], keywords: [], keywords_en: [], tags: [], published_at: ''
             }
             setInitialFormData(empty)
         }
@@ -389,6 +390,7 @@ export default function BlogPostForm({ onClose = () => {}, onSaved = () => {}, p
                 status: postData.status,
                 categories: postData.categories || [],
                 keywords: postData.keywords || [],
+                keywords_en: postData.keywords_en || [],
                 tags: postData.tags || [],
                 // For display only on edit; we won't send it back.
                 published_at: postData.published_at
@@ -421,23 +423,26 @@ export default function BlogPostForm({ onClose = () => {}, onSaved = () => {}, p
         }))
     }
 
+    // Keywords are per-language so PT and EN sets don't pile into one list.
     const handleAddKeyword = (e) => {
         if (e.key === 'Enter' && tagInput.trim()) {
             e.preventDefault()
-            if (!formData.keywords.includes(tagInput.trim())) {
-                setFormData(prev => ({
-                    ...prev,
-                    keywords: [...prev.keywords, tagInput.trim()]
-                }))
-            }
+            const field = activeLang === 'pt' ? 'keywords' : 'keywords_en'
+            const value = tagInput.trim()
+            setFormData(prev => (
+                (prev[field] || []).includes(value)
+                    ? prev
+                    : { ...prev, [field]: [...(prev[field] || []), value] }
+            ))
             setTagInput('')
         }
     }
 
     const handleRemoveKeyword = (kw) => {
+        const field = activeLang === 'pt' ? 'keywords' : 'keywords_en'
         setFormData(prev => ({
             ...prev,
-            keywords: prev.keywords.filter(k => k !== kw)
+            [field]: (prev[field] || []).filter(k => k !== kw)
         }))
     }
 
@@ -1098,7 +1103,7 @@ export default function BlogPostForm({ onClose = () => {}, onSaved = () => {}, p
                                 {t('admin.blog.field_keywords', 'Keywords')}
                             </label>
                             <div className="flex flex-wrap gap-2 mb-2">
-                                {formData.keywords.map((kw, index) => (
+                                {(activeLang === 'pt' ? formData.keywords : formData.keywords_en).map((kw, index) => (
                                     <span
                                         key={index}
                                         className="inline-flex items-center px-3 py-1 text-sm font-medium rounded-full bg-[#009368]/10 text-[#009368]"
@@ -1157,34 +1162,18 @@ export default function BlogPostForm({ onClose = () => {}, onSaved = () => {}, p
                             <div>
                                 <label className="block font-['Onest'] text-xs font-medium text-[#737373] mb-2">
                                     {t('admin.blog.field_publication_link_label', 'Nome do link (ex: Livro Best Practices)')}
+                                    {activeLang === 'en' ? ' (EN)' : ''}
                                 </label>
                                 <input
                                     type="text"
-                                    name="publication_link_label"
-                                    value={formData.publication_link_label}
+                                    name={activeLang === 'pt' ? 'publication_link_label' : 'publication_link_label_en'}
+                                    value={activeLang === 'pt' ? formData.publication_link_label : formData.publication_link_label_en}
                                     onChange={handleInputChange}
                                     className="w-full px-3 py-2 font-['Onest'] text-sm bg-[#fffefc] border border-[#e5e5e5] rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#009368]/30"
                                     placeholder={t('admin.blog.placeholder_link_label', 'Nome do documento')}
                                 />
                             </div>
                         </div>
-
-                        {/* Publication Link Label EN (next to PT) */}
-                        {formData.publication_link && activeLang === 'en' && (
-                            <div>
-                                <label className="block font-['Onest'] text-xs font-medium text-[#737373] mb-2">
-                                    {t('admin.blog.field_publication_link_label', 'Nome do link')} (EN)
-                                </label>
-                                <input
-                                    type="text"
-                                    name="publication_link_label_en"
-                                    value={formData.publication_link_label_en}
-                                    onChange={handleInputChange}
-                                    className="w-full px-3 py-2 font-['Onest'] text-sm bg-[#fffefc] border border-[#e5e5e5] rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#009368]/30"
-                                    placeholder="Document name (EN)"
-                                />
-                            </div>
-                        )}
 
                         {/* Publication date — editable on create, read-only on edit */}
                         <div>

--- a/src/pages/BlogPostPage.jsx
+++ b/src/pages/BlogPostPage.jsx
@@ -33,6 +33,7 @@ function localizePost(raw, lang) {
         content: (en && raw.content_en) || raw.content,
         excerpt: (en && raw.excerpt_en) || raw.excerpt,
         publication_link_label: (en && raw.publication_link_label_en) || raw.publication_link_label,
+        keywords: (en && raw.keywords_en?.length) ? raw.keywords_en : raw.keywords,
     };
 }
 

--- a/src/pages/IndicatorTemplate.jsx
+++ b/src/pages/IndicatorTemplate.jsx
@@ -1023,6 +1023,29 @@ export default function IndicatorTemplate() {
                   </div>
                 </div>
               </div>
+              {/* Time-average (granularity) buttons. Hidden per-indicator via
+                  show_time_averages — off for environment readings (CO, O3,
+                  noise, rainfall) where averaging over time isn't meaningful. */}
+              {indicatorData.show_time_averages !== false && (
+                <div className="flex flex-wrap items-center gap-2 mb-4">
+                  {[
+                    { v: 'auto', label: t('indicator.granularity_auto', 'Auto') },
+                    { v: '0', label: t('indicator.granularity_raw', 'Raw') },
+                    { v: '1h', label: t('indicator.granularity_hourly', 'Horário') },
+                    { v: '1d', label: t('indicator.granularity_daily', 'Diário') },
+                    { v: '1y', label: t('indicator.granularity_annual', 'Anual') },
+                  ].map((opt) => (
+                    <button
+                      key={opt.v}
+                      type="button"
+                      onClick={() => setUiGranularity(opt.v)}
+                      className={`px-3 py-1.5 rounded-full border text-sm font-['Onest'] font-medium transition-colors cursor-pointer ${uiGranularity === opt.v ? 'bg-primary text-white border-primary' : 'bg-[#fffefc] text-[#0a0a0a] border-[#d4d4d4] hover:bg-black/[0.03]'}`}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              )}
               <div className="relative" style={{ minHeight: 288 }}>
                 {dataLoading && (
                   <div className="absolute top-4 right-4 z-10">


### PR DESCRIPTION
This pull request introduces several improvements to the admin indicator and author forms, enhances internationalization support, and adds new configuration options for chart types and time averages. The most significant changes include allowing admins to configure available chart types and the default chart for each indicator, adding an option to toggle the display of time averages, supporting English and Portuguese for author roles, and improving localization for chart granularity and indicator options.

**Admin indicator form enhancements:**

- Added support for configuring which chart types are available for each indicator, including a UI for selecting allowed types and the default chart type, with validation to ensure consistency. (`src/components/admin/IndicatorFormPanel.jsx`, `constants/chartTypes`) [[1]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R8-R24) [[2]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R88-R102) [[3]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R114-R118) [[4]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R132-R137) [[5]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053L122-L123) [[6]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R275-R345)
- Introduced a new `show_time_averages` option to toggle the display of time average buttons (raw, hourly, daily, annual) on indicator pages, with corresponding UI and translations. (`src/components/admin/IndicatorFormPanel.jsx`, `public/locales/en/translation.json`, `public/locales/pt/translation.json`) [[1]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R8-R24) [[2]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R60-R65) [[3]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R275-R345) [[4]](diffhunk://#diff-8e77946ee485378b13babd5fe6bdc1707b77dce605ac6723d7a5b4494dc94925L499-R501) [[5]](diffhunk://#diff-1366ca17680a8c84ec8eacc6393a5a926326cf58687cc51f78d06a955e55a519L499-R501)
- Added a carrying capacity toggle and value input for indicators, allowing admins to define a reference limit. (`src/components/admin/IndicatorFormPanel.jsx`) [[1]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R8-R24) [[2]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R60-R65) [[3]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R132-R137) [[4]](diffhunk://#diff-58ad212029cbf6e089f154669631e8745d2ae990a718dfa5ff04dabceb56b053R275-R345)

**Internationalization and localization:**

- Added English equivalents for author roles, allowing both Portuguese and English versions to be stored and displayed based on the current language. (`src/components/admin/AuthorFormModal.jsx`, `src/pages/AuthorPage.jsx`) [[1]](diffhunk://#diff-ca85ade7f93ff0108a6d70f3d2e5e69c2586cfb4485c8dda3eb569e154d3a208L21-R21) [[2]](diffhunk://#diff-ca85ade7f93ff0108a6d70f3d2e5e69c2586cfb4485c8dda3eb569e154d3a208R66) [[3]](diffhunk://#diff-ca85ade7f93ff0108a6d70f3d2e5e69c2586cfb4485c8dda3eb569e154d3a208R131) [[4]](diffhunk://#diff-ca85ade7f93ff0108a6d70f3d2e5e69c2586cfb4485c8dda3eb569e154d3a208L286-R294) [[5]](diffhunk://#diff-f5dba3b647dac2593852bd695a317e98f79b1d18205d244c7921cab855b83905R112) [[6]](diffhunk://#diff-f5dba3b647dac2593852bd695a317e98f79b1d18205d244c7921cab855b83905L175-R178) [[7]](diffhunk://#diff-f5dba3b647dac2593852bd695a317e98f79b1d18205d244c7921cab855b83905L363-R366)
- Improved translations and added new keys for chart granularity options (auto, hourly, daily, annual) and indicator options in both English and Portuguese. (`public/locales/en/translation.json`, `public/locales/pt/translation.json`) [[1]](diffhunk://#diff-8e77946ee485378b13babd5fe6bdc1707b77dce605ac6723d7a5b4494dc94925L782-R788) [[2]](diffhunk://#diff-1366ca17680a8c84ec8eacc6393a5a926326cf58687cc51f78d06a955e55a519L782-R788)

**Blog post form improvements:**

- Added a `keywords_en` field to blog post forms and state to support English keywords for posts. (`src/pages/BlogPostForm.jsx`) [[1]](diffhunk://#diff-f686322f91741a86337310a318bed319325989cf914a0b4fa762efa3f039fb7bR250) [[2]](diffhunk://#diff-f686322f91741a86337310a318bed319325989cf914a0b4fa762efa3f039fb7bL318-R319) [[3]](diffhunk://#diff-f686322f91741a86337310a318bed319325989cf914a0b4fa762efa3f039fb7bR393)