### PR TITLE
remove warning

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,7 +10,8 @@ import { ResourceProvider } from './contexts/ResourceContext';
 import { WrapperProvider } from './contexts/WrapperContext';
 import ToastContainer from './components/ToastContainer';
 import ConfirmDialogHost from './components/ConfirmDialogHost';
-import UnderDevelopmentModal from './components/UnderDevelopmentModal';
+// Temporarily disabled — re-enable with the <UnderDevelopmentModal /> below.
+// import UnderDevelopmentModal from './components/UnderDevelopmentModal';
 import './i18n';
 import AOS from 'aos';
 import 'aos/dist/aos.css';
@@ -42,7 +43,8 @@ ReactDOM.createRoot(document.getElementById('root')).render(
               />
               <ToastContainer />
               <ConfirmDialogHost />
-              <UnderDevelopmentModal />
+              {/* Temporarily disabled — re-enable to show the platform-under-development notice. */}
+              {/* <UnderDevelopmentModal /> */}
             </WrapperProvider>
           </ResourceProvider>
         </IndicatorProvider>


### PR DESCRIPTION
This pull request temporarily disables the `UnderDevelopmentModal` component in the main application entry point. The modal and its import statement are now commented out, with explanatory comments added to make it easy to re-enable later.

UI changes:

* Commented out the import of `UnderDevelopmentModal` in `src/main.jsx` and added a note explaining it is temporarily disabled.
* Commented out the `<UnderDevelopmentModal />` component in the render tree, with a note about re-enabling it to show the platform-under-development notice.